### PR TITLE
feat: optimize keyed diff and render path for js-framework-benchmark

### DIFF
--- a/docs/performance-improvement/BOTTLENECK_ANALYSIS.md
+++ b/docs/performance-improvement/BOTTLENECK_ANALYSIS.md
@@ -1,0 +1,130 @@
+# BOTTLENECK_ANALYSIS — js-framework-benchmark 기준 병목 분석
+
+- 작성일: 2026-07-27
+- 측정 환경: Node 20.3.0 + jsdom, `dist/lithent.mjs` (feat/alterSpeed 클린 상태 빌드)
+- 측정 스크립트: js-framework-benchmark(keyed) 시나리오 재현 마이크로벤치
+  (table > tr[key] > td×3 구조, renew() 후 microtask flush까지 측정)
+- 관련 문서: [REQUIREMENTS.md](./REQUIREMENTS.md)
+
+## 1. 측정 결과 (기준선)
+
+### 스케일링 (N행 keyed 리스트)
+
+| N | create | 부분갱신(1/10) | swap | replace all | append(+10%) | clear |
+|------:|------:|------:|------:|------:|------:|-----:|
+| 500 | 26.8ms | 11.8ms | 13.8ms | 37.4ms | 11.1ms | 4.2ms |
+| 1,000 | 43.3ms | 26.3ms | 40.1ms | 87.1ms | 33.1ms | 7.5ms |
+| 2,000 | 74.9ms | 85.3ms | 126.6ms | 259.0ms | 121.9ms | 14.6ms |
+| 4,000 | 154.0ms | 379.5ms | 394.2ms | 878.7ms | 419.2ms | 34.2ms |
+
+**판정**: create/clear는 O(n) (2배 스케일 → 약 2배).
+부분갱신·swap·replace·append는 2배 스케일에 **3~4배** 증가 → **O(n²) 확정**.
+
+### js-framework-benchmark 실제 조건 (10,000행)
+
+| 시나리오 (jsfb 대응) | 측정값 | 비고 |
+|---|------:|---|
+| create 10,000 rows | 414ms | O(n)이지만 상수비용 큼 |
+| partial update (1/10 of 10k) | 700ms | 10개 행만 바뀌어도 전체 재-diff |
+| **swap 2 rows (10k table)** | **2,719ms** | 최악 — 전 행 DOM 재삽입 발생 |
+| **append 1,000 to 10,000** | **3,031ms** | 신규 행마다 형제 전체 스캔 |
+| clear 10,000 rows | 90ms | 행 단위 removeChild + 이벤트 재귀 해제 |
+
+> jsdom 측정이므로 절대값은 실브라우저와 다르지만, 스케일링 특성과 병목 순위는 동일하게 적용된다.
+> jsfb 상위권 프레임워크는 이들 시나리오를 수십 ms 안에 처리한다.
+
+## 2. 병목 목록 (영향도 순)
+
+### B1. 순서 변경 시 전체 행 DOM 재삽입 — swap 2.7s의 주범
+
+- 위치: `src/render.ts:117` (`typeSortedUpdate`), `src/render.ts:195` (`startFindNextBrotherElement`)
+- 내용: keyed 리스트에서 순서가 하나라도 어긋나면(`chkDiffLoopOrder` 실패) 모든 자식이
+  `T`(sorted update) 타입이 되어 행마다 DOM에서 뽑아 `insertBefore`로 재삽입한다.
+  삽입 위치 탐색(`startFindNextBrotherElement`)이 `indexOf` + `slice` + 재귀 형제 스캔으로
+  행당 O(n) → 전체 **O(n²) + 10k회 실제 DOM 이동**.
+- 개선안: LIS(최장 증가 부분 수열) 기반으로 **이동이 필요한 최소 노드만** 재배치.
+  swap이라면 2개 노드만 이동해야 정상. jsfb 상위권 구현의 표준 기법.
+
+### B2. 신규 노드 삽입 위치 탐색 O(n²) — append 3.0s의 주범
+
+- 위치: `src/render.ts:195-222` (`startFindNextBrotherElement`), `src/render.ts:224-239`
+- 내용: `A`(add) 타입 노드마다 부모 children에서 `indexOf`(O(n)) + `slice`로 배열 복사 +
+  뒤쪽 형제 전체를 스캔해 다음 실제 엘리먼트를 찾는다. 리스트 끝에 붙는 append조차
+  "뒤에 형제가 없음"을 확인하기 위해 전체 스캔 → 1,000개 추가 시 1,000 × O(10k).
+- 개선안: diff 단계에서 자식 인덱스/다음 형제 엘리먼트를 알고 있으므로 역순 순회로
+  `nextSibling` 캐시를 넘기며 탐색을 O(1)화. `indexOf` 제거(부모가 인덱스 전달).
+
+### B3. keyed 키 매칭 O(n²) — replace/부분갱신/append의 diff 비용
+
+- 위치: `src/diff.ts:303` (`findSameKeyOriginalItem`), `src/diff.ts:291` (`splice(indexOf)`)
+- 내용: 새 자식마다 이전 자식 배열을 `Array.find`로 선형 탐색.
+  - replace all: 키가 전부 miss → 매번 전체 스캔 = n² 회 `getKey` 호출.
+  - 부분갱신(순서 동일): find는 index 0에서 히트하지만 `splice(0,1)`이 매번 배열 전체를
+    shift → O(n²) 메모리 이동.
+- 개선안: 이전 자식들로 `Map<key, WDom>`을 1회(O(n)) 구축하고 조회 O(1),
+  사용된 항목은 마킹만(“splice 제거” 폐지). 남은 항목이 unUsedChildren.
+
+### B4. chkDiffLoopOrder O(n²) — 모든 keyed 업데이트마다 실행
+
+- 위치: `src/diff.ts:137-162`
+- 내용: `filter` 안에 `find` 중첩 ×2회 + `every` — 순서 비교에 3중 O(n²),
+  호출마다 배열 복사 2회, `getKey` 호출 폭증. keyed 리스트가 갱신될 때마다 무조건 실행됨.
+- 개선안: key → index Map으로 O(n) 비교. B1의 LIS 도입 시 이 검사 자체를 흡수 가능
+  (순서 판별과 최소 이동 계산을 한 번의 O(n log n) 패스로 통합).
+
+### B5. 전체 리스트 재-diff + 노드당 할당 비용 — partial update 700ms, create 414ms
+
+- 위치: `src/wDom.ts:204-210` (`remakeChildren`), `src/diff.ts:246-262`, `src/diff.ts:31-65`
+- 내용:
+  - 10개 행만 바뀌어도 10,000행 전체의 wDom을 새로 만들고 전체를 재귀 diff.
+  - 노드당 `getParent: () => ...` 클로저를 **h() 단계와 diff 단계에서 각각 새로 할당** +
+    `Object.assign` 호출. 행당 노드 ~10개 × 10k행 = 렌더당 클로저 20만 개 수준.
+  - 텍스트/props가 동일해도 노드 재생성 자체는 항상 수행됨.
+- 개선안: 클로저 대신 `parent` 필드 직접 참조(할당 1회·공유), props 얕은 비교로
+  변경 없는 노드의 `U` 처리 조기 종료, `assign` 대신 리터럴 생성.
+
+### B6. prop/이벤트 처리의 상수 비용 — create·clear 경로
+
+- 위치: `src/render.ts:329-394` (`updateProps`), `src/render.ts:265-277` (`removeEvent`),
+  `src/utils/predicator.ts:131-138` (`hasAccessorMethods`), `src/utils/predicator.ts:96-97` (`checkVirtualType`)
+- 내용:
+  - prop마다 `Object.entries` 배열 생성 + `/^on/` 정규식 매칭.
+  - 일반 attr마다 `hasAccessorMethods` → `Object.getOwnPropertyDescriptor` 프로토타입 조회
+    (create 10k에서 attr 수만큼 반복).
+  - `checkVirtualType`이 호출마다 `['f','l']` 배열을 새로 만들어 `includes` — 최다 빈도 호출부.
+  - clear: 행마다 `removeChild` + `recursiveRemoveEvent` 전체 재귀.
+- 개선안: `for-in` 루프 + `key[0]==='o'&&key[1]==='n'` 문자 비교, accessor 검사 결과를
+  태그·키별로 캐시, `checkVirtualType`은 `type === 'f' || type === 'l'`로 교체,
+  clear는 전체 삭제 감지 시 부모 `textContent = ''` 일괄 처리.
+
+## 3. 시나리오 → 병목 매핑 (jsfb keyed 기준)
+
+| jsfb 시나리오 | 지배 병목 | 예상 효과 |
+|---|---|---|
+| swap rows | **B1** (+B4) | O(n²)+전행 DOM 이동 → 노드 2개 이동 |
+| append rows to large table | **B2** (+B3) | 3.0s → O(n) 수준 |
+| replace all rows | **B3, B4** | diff 자체 O(n)화 |
+| partial update | B3(splice), B4, B5 | 700ms 중 diff 고정비 제거 |
+| create rows (1k/10k) | B5, B6 | 상수비용 절감 |
+| select row | B5 | 전체 재-diff 고정비 절감 |
+| remove row | B3, B2 | 동반 개선 |
+| clear rows | B6 | 90ms → 일괄 삭제 |
+| startup/메모리 | B5(클로저), B6 | 노드당 할당 감소 |
+
+## 4. 권장 작업 순서
+
+1. **P0 — B3+B4**: keyed diff를 Map 기반 O(n)으로 (diff.ts 국소 변경, 리스크 낮음, replace/partial 즉효)
+2. **P0 — B2**: 삽입 위치 탐색 O(1)화 (render.ts, append/create 즉효)
+3. **P1 — B1**: LIS 기반 최소 이동 (B4의 순서 검사와 통합, swap 해결 — 구조 변경 폭 가장 큼)
+4. **P1 — B5**: 클로저/assign 할당 절감 + 무변경 노드 조기 종료
+5. **P2 — B6**: 상수 비용 미세 최적화 (정규식/디스크립터/배열 할당 제거, clear 일괄 삭제)
+
+각 단계는 독립적으로 벤치 전/후 측정 가능하며, 1→2→3 순서로만 해도
+jsfb 주요 시나리오(swap 제외)의 O(n²)가 제거된다.
+
+## 5. 재현 방법
+
+측정 스크립트: [`bench/bench.mjs`](./bench/bench.mjs) (스케일링 500~4k),
+[`bench/bench10k.mjs`](./bench/bench10k.mjs) (jsfb 10k 조건). `node bench/bench.mjs`로 실행.
+핵심: jsdom 전역 세팅 → `dist/lithent.mjs` import → keyed tr 리스트 → `renew()` 후
+`await Promise.resolve()`(microtask 배칭 flush)까지 측정.

--- a/docs/performance-improvement/CODE_WALKTHROUGH.md
+++ b/docs/performance-improvement/CODE_WALKTHROUGH.md
@@ -1,0 +1,489 @@
+# CODE_WALKTHROUGH — diff.ts / render.ts 변경 상세 해설
+
+- 기준: `e19ff29`(작업 전) → `cb0d26c`(현재), 브랜치 `feat/alterSpeed`
+- 대상 독자: 이 브랜치의 코드 변경을 리뷰하거나 이어받을 사람
+- 관련 문서: [BOTTLENECK_ANALYSIS.md](./BOTTLENECK_ANALYSIS.md)(왜 느렸나),
+  [DESIGN.md](./DESIGN.md)(설계 결정), [IMPLEMENT.md](./IMPLEMENT.md)(측정 기록)
+
+---
+
+## 1. 한 장 요약
+
+기존 keyed 리스트 처리에는 O(n²) 경로가 4개 있었다.
+
+| 병목 | 위치(변경 전) | 증상 (10k행, jsdom) |
+|---|---|---|
+| 키 매칭이 `find`+`splice` 선형 탐색 | `diff.ts` `findSameKeyOriginalItem` | replace 879ms@4k |
+| 순서 판정이 3중 중첩 순회 | `diff.ts` `chkDiffLoopOrder` | 부분갱신 700ms |
+| 순서가 어긋나면 **전 행을 DOM에서 재삽입** | `render.ts` `typeSortedUpdate`(T 경로) | swap 2,719ms |
+| 삽입 위치를 형제 전체 스캔으로 탐색 | `render.ts` `startFindNextBrotherElement` | append 3,031ms |
+
+이번 변경의 골자는 **역할 재배치**다:
+
+```
+[변경 전]
+diff 단계:   자식마다 선형 탐색으로 짝 찾기 (O(n²))
+             리스트 순서가 같은지 별도로 3중 순회 검사 (O(n²)) → 'L' 마킹
+render 단계: 'L'이면 제자리 갱신, 아니면 전 행 재삽입 (행마다 O(n) 앵커 탐색)
+
+[변경 후]
+diff 단계:   Map으로 짝 찾기 (O(n)) + 각 자식에 "이전 인덱스(oi)"만 기록
+render 단계: updateChildren이 oi 수열로 LIS를 구해 (O(n log n))
+             "제자리에 둘 자식"과 "이동할 자식"을 판별,
+             이동/신규만 앵커 하나를 굴리며 역순으로 insertBefore (O(n))
+```
+
+순서 판정('L')과 이동 실행이 별개였던 구조를, "이동 최소화"라는 하나의 문제로
+합쳐서 render 쪽 `updateChildren`에 몰아넣은 것이 핵심이다.
+그 결과 `chkDiffLoopOrder`, `findSameKeyOriginalItem`, `'L'` RenderType이 통째로 사라졌다.
+
+---
+
+## 2. 새 파이프라인: diff와 render가 주고받는 것
+
+diff와 render를 잇는 매개는 wDom 노드에 붙는 short-key 메타데이터다.
+이번에 `oi` 하나가 추가됐다 (`types/index.ts`):
+
+```ts
+nr?: RenderType; // needRerender — 기존: A/D/R/U/S/T/N ('L'은 삭제됨)
+oi?: number;     // originalIndex — [신규] keyed 매칭된 자식의 "이전 리스트에서의 위치"
+```
+
+흐름 전체:
+
+```
+renew()
+  └─ makeNewWDomTree (diff.ts)
+       └─ 리스트('l') 자식이 keyed면 diffLoopChildren
+            ├─ 이전 자식들로 Map<key, index> 구축        …… O(n)
+            ├─ 새 자식마다 Map 조회로 짝 찾기             …… O(1)씩
+            ├─ 짝이 있으면 child.oi = 이전 인덱스 기록
+            └─ 짝이 안 된 이전 자식들 → typeDeleteUnused (unmount/이벤트해제/DOM제거)
+  └─ wDomUpdate (render.ts)
+       └─ typeUpdate → updateChildren
+            ├─ [판별] 자식 중 A/T/S 또는 oi 보유가 있나? 없으면 기존 그대로
+            ├─ [콘텐츠 패스: 왼→오] T는 내용만 갱신, A/S는 엘리먼트 생성만(삽입 보류)
+            ├─ [LIS] oi 수열의 최장 증가 부분 수열 = "제자리에 두어도 되는 자식들"
+            ├─ [꼬리 fast-append] 끝에 연속된 신규 run은 순서대로 바로 삽입
+            ├─ [배치 패스: 오→왼] 신규 + LIS 밖 자식만 anchor 앞에 insertBefore
+            └─ [정리] oi/nr/oc/op 일괄 삭제, mount 콜백 일괄 실행
+```
+
+---
+
+## 3. diff.ts 변경 상세
+
+### 3.1 `diffLoopChildren` — 키 매칭 Map화 + oi 기록 (핵심)
+
+**변경 전** — 새 자식마다 남은 이전 자식 배열을 `find`로 선형 탐색하고,
+쓴 항목은 `splice`로 제거(배열 전체 shift 발생):
+
+```ts
+const origCh = [...(originalWDom.children || [])];
+const remaked = (newWDom.children || []).map(item => {
+  const orig = findSameKeyOriginalItem(item, origCh);   // O(n) 탐색
+  const child = makeNewWDomTree(item, orig);
+  if (orig) origCh.splice(origCh.indexOf(orig), 1);     // O(n) + O(n)
+  child.getParent = () => newWDom;                      // 자식마다 클로저 할당
+  return child;
+});
+return [remaked, origCh];  // 남은 것 = 삭제 대상
+```
+
+n개 자식 × 자식당 O(n) = **O(n²)**. replace-all(키 전부 miss)에서는 매번
+전체를 헛스캔하고, 부분갱신(키 전부 hit)에서도 `splice(0,1)`이 매번 배열을
+통째로 밀어서 O(n²)였다.
+
+**변경 후** — 이전 자식들로 `Map<key, index>`를 한 번 만들고 O(1) 조회.
+제거는 `keyMap.delete`(O(1))로 대체. 짝이 된 자식에는 `oi`(이전 인덱스)를 기록:
+
+```ts
+const origChildren = originalWDom.children || [];
+const keyMap = new Map<unknown, number>();
+origChildren.forEach((item, index) => {
+  const key = getKey(item);
+  if (!keyMap.has(key)) keyMap.set(key, index);   // 중복 key는 첫 등장만
+});
+
+const getParent = () => newWDom;                  // 클로저는 부모당 1개 공유
+const remaked = (newWDom.children || []).map(item => {
+  const origIndex = keyMap.get(getKey(item));
+  const matched = origIndex !== undefined;
+  if (matched) keyMap.delete(key);
+
+  const child = makeNewWDomTree(item, matched ? origChildren[origIndex] : undefined);
+  if (matched) child.oi = origIndex;              // ★ render의 LIS 입력
+  child.getParent = getParent;
+  return child;
+});
+
+return [remaked, [...keyMap.values()].map(index => origChildren[index])];
+// Map에 남은 인덱스들 = 짝이 안 된(삭제될) 이전 자식들
+```
+
+주의할 동작 차이 하나: **중복 key**. 기존은 "남은 것 중 첫 매칭"이라 같은
+key 2개가 각각 짝을 찾을 수 있었지만, Map은 첫 등장만 유지하므로 두 번째
+중복은 삭제+재생성된다. 중복 key는 원래 금지된 사용이므로 허용 처리했다.
+
+### 3.2 `chkDiffLoopOrder` 삭제 + `'L'` RenderType 폐기
+
+**변경 전** — keyed 리스트가 갱신될 때마다 "공통 key들의 상대 순서가
+같은가"를 검사했다. `filter` 안에 `find`가 중첩된 형태 ×2 + `every`:
+
+```ts
+const newChildren = [...].filter(item =>
+  origChildren.find(newItem => getKey(item) === getKey(newItem)));  // O(n²)
+const filteredChildren = origChildren.filter(item =>
+  newChildren.find(newItem => getKey(item) === getKey(newItem)));   // O(n²)
+isSame = filteredChildren.every((item, i) => getKey(item) === getKey(newChildren[i]));
+```
+
+순서가 같으면 리스트에 `'L'`을 마킹하고, render의 T 경로가 `parent.nr === 'L'`
+이면 재삽입을 생략했다. 즉 **"전부 제자리" 아니면 "전부 재삽입"의 이분법**이었고,
+swap처럼 딱 2개만 어긋나도 전 행이 재삽입됐다.
+
+**변경 후** — 함수와 `'L'` 마킹 블록을 통째로 삭제:
+
+```ts
+return isSameType ? (isKeyChecked ? 'T' : 'U') : isKeyChecked ? 'S' : 'R';
+```
+
+"순서가 같은가?"라는 질문 자체가 필요 없어졌다. render의 LIS가
+"순서가 같으면 이동 0개"라는 답을 자연스럽게 내놓기 때문이다
+(oi 수열이 이미 증가 수열이면 전부 LIS에 포함 → 아무도 안 움직임).
+`'L'`은 부여처가 사라졌으므로 타입 정의·핸들러 맵·render의 분기까지
+연쇄적으로 제거했다 (§4.4).
+
+### 3.3 `remakeChildrenForAdd` / `remakeChildrenForUpdate` — 클로저 공유
+
+**변경 전**은 자식마다 `assign(child, { getParent: () => newWDom })`로
+클로저 + 임시 객체를 새로 만들었다. 10k행 × 행당 노드 ~7개면 렌더 한 번에
+클로저 수만 개다. **변경 후**는 부모당 클로저 1개를 만들어 자식들이 공유하고,
+`assign` 호출 대신 프로퍼티 직접 대입으로 바꿨다:
+
+```ts
+const getParent = () => newWDom;   // 1회 생성
+return (newWDom.children || []).map(item => {
+  const child = makeNewWDomTree(item);
+  child.getParent = getParent;     // 참조 공유
+  return child;
+});
+```
+
+`getParent()` 함수 인터페이스는 그대로라 호출부 변경이 없다 (DESIGN DC-2).
+같은 패턴이 `wDom.ts`의 `remakeChildren`(h() 단계)에도 적용됐다.
+
+### 3.4 unused 자식 정리를 `typeDeleteUnused`로 위임
+
+기존에 diff 안에 인라인으로 있던 unmount → 이벤트 해제 → DOM 제거 3단계를
+render.ts의 `typeDeleteUnused`로 옮겼다. 실행 내용과 순서는 동일하다.
+(render로 옮긴 이유: DOM 제거 로직과 같은 파일에 두고, §4.5의 bulk 삭제와
+결합할 여지를 남기기 위해서다.)
+
+---
+
+## 4. render.ts 변경 상세
+
+### 4.1 `updateChildren` — 신규, 이번 변경의 심장
+
+기존 `typeUpdate`는 자식을 그냥 순회했다:
+
+```ts
+(newWDom.children || []).forEach(childItem => wDomUpdate(childItem));
+```
+
+그러면 자식마다 render 핸들러가 **독립적으로** 실행된다. `A`(추가)는
+자기 삽입 위치를 스스로 찾고(형제 전체 스캔 O(n) → 전체 O(n²)),
+`T`(keyed 갱신)는 부모가 `'L'`이 아니면 무조건 자기를 재삽입했다.
+
+새 `updateChildren`은 리스트 부모의 자식 배치를 **한 곳에서 전역으로** 결정한다.
+5단계로 나눠 읽으면 된다:
+
+**(1) 판별** — 배치가 필요 없는 평범한 경우는 기존 경로 그대로:
+
+```ts
+if (newWDom.type === 'l') {
+  for (const item of children) {
+    if ('ATS'.includes(item.nr as string) || item.oi !== undefined) {
+      needPlace = true;
+      break;
+    }
+  }
+}
+if (!needPlace) {
+  children.forEach(childItem => wDomUpdate(childItem));  // 기존과 동일
+  return;
+}
+```
+
+리스트가 아니거나(fragment/element 부모), keyed 변화가 전혀 없으면
+이 함수는 아무것도 새로 하지 않는다. **비 keyed 경로의 동작은 그대로**다.
+
+**(2) 콘텐츠 패스 (왼→오)** — 라이프사이클 순서를 지키는 구간:
+
+```ts
+children.forEach((item, index) => {
+  const nr = item.nr;
+  if (nr === 'A' || nr === 'S') {
+    if (nr === 'S') typeDelete(item);       // S = 같은 key인데 타입이 바뀜: 옛것 제거
+    created[index] = wDomToDom(item);       // 엘리먼트 "생성만" — 삽입은 나중에
+    createdCount++;
+  } else if (nr === 'T') {
+    typeUpdate(item);                       // 내용만 갱신 — 재삽입 없음 (★)
+  } else {
+    wDomUpdate(item);                       // U/R/D/N 등은 기존 핸들러 그대로
+  }
+  if (item.oi !== undefined && created[index] === undefined) {
+    matchedIndexes.push(index);             // LIS 입력 수집
+    oiSeq.push(item.oi);
+  }
+});
+```
+
+★가 기존과의 결정적 차이다. 예전 T 경로(`typeSortedUpdate`)는
+"갱신 + 재삽입"이 한 몸이었는데, 여기서는 갱신만 하고 **이동 여부는
+다음 단계의 LIS가 결정**한다. 왼→오 순회라서 update 콜백 순서가 기존과 같고,
+신규 노드의 mount 콜백도 생성 시점에 왼→오로 큐잉된다.
+
+**(3) LIS — 제자리에 둘 자식 선별**:
+
+```ts
+const stay = new Set(getLisPositions(oiSeq).map(pos => matchedIndexes[pos]));
+```
+
+`oiSeq`는 "새 순서로 나열했을 때 각 자식의 옛 위치" 수열이다.
+이 수열의 **최장 증가 부분 수열(LIS)에 속한 자식들은 상대 순서가 이미
+맞으므로 건드리지 않아도 된다**. 나머지만 이동하면 이동 횟수가 최소가 된다.
+
+예: `[1,2,3,4,5]` → `[1,4,3,2,5]` (2와 4를 swap)
+- oiSeq = `[0, 3, 2, 1, 4]` (새 위치별 옛 인덱스)
+- LIS = `0, 2, 4` 또는 `0, 1, 4` (길이 3) → 예컨대 {1, 3, 5}는 제자리
+- 이동은 4와 2, **딱 2개**. 기존 코드는 5개 전부 재삽입했다.
+
+**(4) 꼬리 fast-append** — 가장 흔한 패턴(끝에 추가) 전용 지름길:
+
+```ts
+let tail = children.length;
+while (tail > 0 && created[tail - 1] !== undefined) tail--;   // 끝의 연속 신규 run
+
+for (let i = tail; i < children.length; i++) {
+  const el = created[i];
+  if (el && parentEl && children[i].tag !== 'portal') {
+    parentEl.insertBefore(el, baseAnchor || null);   // null이면 appendChild와 동일
+  }
+}
+```
+
+`baseAnchor`는 "리스트 전체의 다음 형제 엘리먼트"다
+(`<ul>{list}<li class="tail">` 같은 구조에서 `.tail`). 이것이 없으면 순수
+append이고, 있으면 그 앞에 왼→오로 차례로 insertBefore 하면 순서가 맞는다.
+이 run을 역순 배치 패스에서 빼는 이유는 두 가지다:
+① 뒤에서부터 insertBefore를 걸면 jsdom에서 참조 노드의 인덱스를 매번
+재계산해 O(위치)가 되는 측정 왜곡이 있고(실브라우저에서도 append가 더 싸다),
+② append는 앵커 계산 자체가 필요 없다.
+
+**(5) 배치 패스 (오→왼)** — 이동/신규 최소 삽입:
+
+```ts
+if (stay.size !== matchedIndexes.length ||          // 이동할 게 있거나
+    createdCount > children.length - tail) {        // 꼬리 밖 신규가 있으면
+  let anchor = findChildFragmentNextElement(children.slice(tail)) || baseAnchor;
+
+  for (let i = tail - 1; i >= 0; i--) {
+    const item = children[i];
+    const isNew = created[i] !== undefined;
+    const needMove = item.oi !== undefined && !isNew && !stay.has(i);
+
+    if ((isNew || needMove) && parentEl && item.tag !== 'portal') {
+      const el = isNew ? created[i] : getElementFromFragment(item);
+      if (el) parentEl.insertBefore(el, anchor || null);
+    }
+
+    const first = findChildFragmentNextElement([item]);   // 이 자식의 첫 실제 el
+    if (first) anchor = first;                            // 다음(왼쪽) 자식의 앵커가 됨
+  }
+}
+```
+
+오른쪽 끝에서 왼쪽으로 가며 `anchor`(= 지금 위치 기준 "내 오른쪽에 와야 할
+첫 실제 엘리먼트")를 갱신한다. 각 자식은:
+- **LIS에 속하면** 아무것도 안 하고 자기 el을 anchor로 넘겨준다.
+- **이동 대상이면** `insertBefore(el, anchor)` 한 번으로 최종 위치에 꽂힌다.
+- **신규면** 콘텐츠 패스에서 만들어둔 el을 같은 방식으로 꽂는다.
+- Fragment 자식은 `getElementFromFragment`가 하위 실제 el들을 모아 이동시킨다.
+
+역순이어야 하는 이유: 자식 i의 올바른 앵커는 "i+1 이후 자식들의 **최종**
+위치"인데, 오→왼으로 진행하면 오른쪽은 항상 이미 확정돼 있다.
+
+마지막으로 정리:
+
+```ts
+children.forEach(clearDiffMeta);   // oi/nr/oc/op 일괄 삭제
+execMountedQueue();                // 신규 노드 mount 콜백 일괄 실행 (순서는 왼→오)
+```
+
+mount 콜백이 "삽입마다 즉시"에서 "전부 삽입 후 일괄"로 바뀌었다.
+순서(왼→오)는 유지되며, 콜백 시점엔 형제가 모두 DOM에 있으므로
+오히려 더 일관적이다. (`core-loopLifecycleOrder.tsx`가 이 순서를 고정)
+
+### 4.2 `getLisPositions` — 신규 유틸
+
+이진 탐색 기반 표준 LIS, O(n log n). `seq`에서 LIS를 이루는 **위치들**을 반환한다.
+
+```
+seq:      [0, 3, 2, 1, 4]
+반환:     [0, 2, 4]        (값 0 < 2 < 4 — 하나의 유효한 LIS 위치 집합)
+```
+
+- `result`: "길이 k인 증가 수열의 최소 꼬리"가 있는 위치들 (이진 탐색 대상)
+- `prev`: 역추적용 — 각 위치가 어느 위치 뒤에 붙었는지
+- 말미의 `while (i--)` 루프가 `prev`를 따라 실제 LIS 위치를 복원
+
+증가 수열이 이어지는 동안은 이진 탐색 없이 바로 push하는 fast path가 있어서,
+정순 유지 케이스(부분갱신/append)는 사실상 O(n)으로 흐른다.
+
+### 4.3 `typeSortedUpdate` / `typeAdd` — 'L' 분기 소멸로 단순화
+
+`'L'`이 사라지면서 두 함수의 분기가 죽은 코드가 됐다:
+
+```ts
+// typeSortedUpdate: before — parent.nr !== 'L' 검사가 재삽입 여부를 갈랐음
+// after — 항상 재삽입 (updateChildren이 T를 가로채므로, 여기로 오는 건
+//         "리스트 자식 컴포넌트가 단독으로 renew된 경우"뿐이며 기존과 동일 동작)
+const typeSortedUpdate = (newWDom: WDom) => {
+  typeUpdate(newWDom);
+  if (getParent(newWDom) || newWDom.isRoot) {
+    typeAdd(newWDom, getElementFromFragment(newWDom));
+  }
+};
+```
+
+주의: `renderHandlers.T → typeSortedUpdate`는 여전히 살아 있다.
+keyed 리스트 안의 컴포넌트 하나가 **자기 renew()로 단독 갱신**되면 diff 루트가
+그 컴포넌트라서 updateChildren을 거치지 않고 T로 직행하는데, 이 경로는
+변경 전에도 재삽입이었고 지금도 같다.
+
+`typeAdd`는 앵커 삼항이 `insertBefore(el, nextEl || null)` 한 줄로 줄었다
+(DOM 스펙상 참조가 null이면 append와 동일).
+
+### 4.4 `findChildWithRemoveElement` — clear 일괄 삭제 (DC-4)
+
+리스트 전체가 삭제될 때(전형적으로 clear rows) 타는 경로다.
+빈 새 리스트는 keyed 경로 진입 조건(첫 자식 key 존재)을 못 넘기 때문에
+리스트 노드 자체가 `R`(replace)로 판정되고, 옛 자식들(`oc`)이 여기서 지워진다.
+
+**변경 전**: 행마다 `el.remove()` — 10k번의 개별 DOM 제거.
+**변경 후**: 부모가 정확히 이 자식들만 담고 있으면 `parent.textContent = ''` 한 방:
+
+```ts
+let count = 0;
+for (let node = parent.firstChild; node; node = node.nextSibling) count++;
+// ⚠ parent.childNodes.length를 쓰면 안 됨: jsdom은 live NodeList를 만들어
+//   이후 그 부모의 모든 삽입/삭제에 갱신 비용을 물린다 (벤치 3~10배 오염)
+
+if (items.length > 1 && count === items.length &&
+    items.every(item => /* 전부 element/text이고 HTML/portal 아님 */)) {
+  parent.textContent = '';
+  items.forEach(item => delete item.el);
+  return;
+}
+// 조건 미충족 시 기존 per-item 루프 그대로 (동작 보존)
+```
+
+안전조건이 핵심이다: **부모의 실제 자식 수 == 삭제 대상 수**여야만 발동한다.
+리스트 옆에 다른 형제가 있으면(count 불일치) 기존 경로로 떨어진다.
+unmount 콜백/이벤트 해제는 이 함수에 오기 전에 기존 순서대로 이미 끝나 있다.
+
+### 4.5 `wDomChildrenToDom` — 중간 DocumentFragment 제거
+
+**변경 전**: 부모 노드마다 `DF()`를 만들어 자식들을 모았다가 부모에 붙였다.
+10k행 create면 부모 수만큼(~4만 개) DocumentFragment가 생성·폐기된다.
+**변경 후**: 이 함수는 초기 서브트리 구성 중에만 불리고 그 시점의 부모는
+아직 문서 밖이므로, 자식을 부모에 **직접 append**해도 결과가 같다:
+
+```ts
+children.forEach((childItem: WDom) => {
+  if (childItem.type) {
+    const childElement = wDomToDom(childItem, isHydration);
+    if (childItem.tag !== 'portal' && !isHydration && parentElement) {
+      parentElement.appendChild(childElement);
+    }
+  }
+});
+```
+
+create 10k가 433→~300ms로 내려간 주 요인 (GC 압박 감소).
+
+### 4.6 `updateProps` / `removeEvent` / `updateStyle` — 상수비용 절감
+
+핫루프에서 반복되던 세 가지 비용을 제거했다. 로직 분기는 동일하다.
+
+| before | after | 이유 |
+|---|---|---|
+| `entries(props).forEach(([k,v]) => …)` | `for (const k in props)` | prop마다 `[k,v]` 배열 할당 제거 |
+| `dataKey.match(/^on/)` (×3곳) | `dataKey[0]==='o' && dataKey[1]==='n'` | 정규식 매칭 → 문자 비교 |
+| `keys(originalProps).forEach(...)` | `for (const k in originalProps)` | 배열 생성 제거 |
+
+하나 지워진 비교가 있다: `if (dataKey === 'key' || dataValue === originalProps[dataKey])`
+→ `if (dataKey === 'key')`. 뒤 조건은 **루프 첫머리에서 이미 같으면 `continue`로
+빠졌고 그 사이에 값을 바꾸는 코드가 없어** 항상 false인 죽은 조건이었다.
+("값이 같으면 스킵" 동작은 루프 첫머리에 그대로 있다.)
+
+`wDomUpdate` 말미의 `delete nr/oc/op` 3연발은 `clearDiffMeta` 헬퍼 재사용으로 교체.
+
+### 4.7 `typeDeleteUnused` — diff에서 넘어온 정리 루틴
+
+```ts
+export const typeDeleteUnused = (items: WDom[]) => {
+  items.forEach(item => {
+    runUnmountQueueFromWDom(item);   // 1. unmount 콜백
+    recursiveRemoveEvent(item);      // 2. 이벤트 해제
+    typeDelete(item);                // 3. DOM 제거
+  });
+};
+```
+
+diff.ts에 인라인으로 있던 것을 옮겼을 뿐, 항목당 실행 순서는 동일하다.
+
+---
+
+## 5. 함께 바뀐 보조 파일 (요약)
+
+| 파일 | 변경 | 이유 |
+|---|---|---|
+| `types/index.ts` | `oi?: number` 추가, `'L'` RenderType 삭제 | §2, §3.2 |
+| `wDom.ts` `remakeChildren` | getParent 클로저 부모당 1개 공유 | §3.3과 동일 패턴 (h() 단계) |
+| `predicator.ts` `checkVirtualType` | `['f','l'].includes(type)` → `type==='f'\|\|type==='l'` | 호출마다 배열 할당 제거 (최다 빈도 호출부) |
+| `predicator.ts` `hasAccessorMethods` | `getOwnPropertyDescriptor` 결과를 `nodeName+'\|'+key`로 캐시 | create 경로에서 attr마다 프로토타입 조회하던 것 제거. HTML nodeName은 대문자·SVG는 소문자라 키 충돌 없음 |
+
+---
+
+## 6. 성능 결과와 동작 차이
+
+### 결과 (10k행, jsdom — IMPLEMENT.md에 단계별 기록)
+
+| 시나리오 | before | after |
+|---|---:|---:|
+| swap 2행 | 2,719ms | ~83ms |
+| append 1,000행 | 3,031ms | ~94ms |
+| partial update (1/10) | 700ms | ~96ms |
+| create 10k | 414ms | ~301ms |
+| clear 10k | 90ms | ~65ms(정상상태) |
+| min 번들 | gzip 4,510 / br 4,169B | gzip 5,133(+623) / br 4,734B(+565) |
+
+### 의도된 동작 차이 (최종 DOM·API·콜백 순서는 동일)
+
+1. **재정렬 시 이동하지 않는 행은 DOM에서 떼어지지 않는다** — 포커스·CSS
+   트랜지션·iframe 상태가 보존된다 (기존엔 전 행 재삽입으로 전부 리셋).
+2. **여러 행 추가 시 mount 콜백이 "전부 삽입 후 일괄" 실행** — 순서는 왼→오 유지.
+3. **중복 key**는 첫 등장만 매칭 (금지된 사용, §3.1).
+4. clear가 개별 제거 대신 일괄 제거라 MutationObserver 기록 단위가 다름 (외부 관찰자 한정).
+
+### 회귀 안전망
+
+- `src/tests/core-loopMoveOrder.tsx` — swap/역순/셔플/append/중간삽입/clear/재충전
+  8케이스, 전 케이스에 "리스트 경계 형제 침범" 검증 포함
+- `src/tests/core-loopLifecycleOrder.tsx` — mount 순서(초기·삽입), 이동 시 재마운트
+  없음, unmount 순서 4케이스
+- `docs/performance-improvement/bench/verify-order.mjs` — 무작위 셔플 포함 18케이스
+- 기존 전체 스위트 195테스트 통과

--- a/docs/performance-improvement/DESIGN.md
+++ b/docs/performance-improvement/DESIGN.md
@@ -1,0 +1,150 @@
+# DESIGN — Lithent 렌더링 성능 개선
+
+- 작성일: 2026-07-27
+- 상태: **초안 — DC-1~DC-4 결정 대기 (구현 착수 전 확정)**
+- 관련 문서: [REQUIREMENTS.md](./REQUIREMENTS.md), [BOTTLENECK_ANALYSIS.md](./BOTTLENECK_ANALYSIS.md)
+
+## 1. 설계 원칙
+
+- P1. **2-pass 구조 유지**: diff(`makeNewWDomTree` → `nr` 마킹) / render(`wDomUpdate` → 실행)
+  분리를 바꾸지 않는다. 알고리즘 교체는 각 pass 내부에서만 일어난다 (REQUIREMENTS N3).
+- P2. **참조 안정성 유지 (C2)**: WDom의 `props`/`children` 배열 인스턴스는 조상·클로저가
+  공유하므로 교체가 아닌 in-place 뮤테이션으로만 동기화한다 (`src/diff.ts:184-190`).
+- P3. **계약 보존**: 새 노드의 `el` 상속, `nr`/`oc`/`op` short-key 규약, unmount 큐 실행
+  시점, microtask 배칭을 기존과 동일하게 유지한다.
+- P4. **크기 게이트**: 각 페이즈 종료 시 min 빌드 brotli를 실측하고, 예산(5,120B br)
+  초과가 예상되면 다음 페이즈 진입 전에 설계를 재검토한다.
+
+## 2. 채택 알고리즘 (확정)
+
+**Vue3 조합 = Map 기반 키 매칭 + LIS 기반 최소 이동** (2026-07-27 사용자 결정)
+
+- 매칭: 이전 자식들로 `Map<key, {node, index}>`를 1회 구축(O(n)), 새 자식마다 O(1) 조회.
+- 이동: 매칭된 자식들의 oldIndex 수열에서 LIS(최장 증가 부분 수열)를 O(n log n)으로
+  계산, LIS에 속한 노드는 제자리 유지, 나머지만 `insertBefore`로 이동.
+- 폴백: 페이즈 1 크기 실측 후 LIS 예산 초과 시 React식 lastPlacedIndex 휴리스틱
+  (+200~300B)으로 후퇴 가능하도록 이동 로직을 단일 함수로 격리한다.
+
+## 3. 상세 설계
+
+### D1. keyed 매칭 Map화 — B3 해결 (`src/diff.ts`)
+
+`diffLoopChildren` 재작성:
+
+1. `origCh`로 `Map<key, WDom>` + oldIndex 기록을 1회 구축. 중복 key는 첫 항목 우선
+   (현행 `find` 동작과 동일 — 동작 보존).
+2. 새 자식 순회: Map 조회로 짝을 찾고 `makeNewWDomTree(item, orig)` 호출(기존과 동일).
+   사용된 항목은 Map에서 `delete` (splice 제거 폐지 — O(1)).
+3. 순회 후 Map에 남은 항목 = `unUsedChildren` (기존 unmount/이벤트 해제 경로 그대로).
+4. 각 새 자식에 매칭된 oldIndex를 임시 필드로 기록 → D3의 LIS 입력.
+   (short-key, diff 종료 시 삭제 — `nr`/`oc`와 동일한 수명 관리)
+
+`el` 상속, `runUpdate` in-place 동기화(P2), `getParent` 연결은 기존 코드 경로를 그대로
+지나므로 변경 없음.
+
+### D2. chkDiffLoopOrder 제거 — B4 해결 (`src/diff.ts:137-162`)
+
+- 함수 전체 삭제. "순서가 같은가"라는 사전 판정 자체가 불필요해진다 —
+  D3의 LIS가 "순서가 같으면 이동 0개"라는 사실을 자연스럽게 도출하기 때문.
+- `'L'` RenderType의 의미 재정의 필요 → **DC-1**.
+
+### D3. LIS 기반 최소 이동 — B1 해결 (`src/diff.ts` 계산, `src/render.ts` 실행)
+
+- diff 단계: D1이 기록한 oldIndex 수열로 LIS 계산 (Vue3 `getSequence` 방식,
+  이진 탐색 + predecessor 역추적, ~40줄). LIS 밖의 노드에만 이동 마크.
+- render 단계: 리스트 자식을 **역순 순회**하며 `anchor`(다음 실제 DOM 엘리먼트)를
+  로컬 변수로 전달. 이동 마크 노드만 `insertBefore(el, anchor)`, 나머지는 anchor 갱신만.
+- 신규 노드(`A`)도 같은 역순 순회에서 anchor를 재사용 → D4와 자연 통합.
+- 이동 마킹 방식(새 `nr` 코드 vs 기존 `T` 재활용) → **DC-1**.
+
+### D4. 삽입 앵커 O(1)화 — B2 해결 (`src/render.ts:195-239`)
+
+- 리스트 경로: D3의 역순 순회 anchor로 대체 — `startFindNextBrotherElement` 호출 자체가
+  사라진다 (`indexOf`/`slice`/재귀 스캔 제거).
+- 비리스트 경로(Fragment 혼합, 단일 `A` 노드 등): `startFindNextBrotherElement`를
+  유지하되 `indexOf` → 부모가 자식 순회 시 인덱스를 인자로 전달, `slice` 복사 제거
+  (인덱스 기반 순회로 대체). Fragment/portal 재귀 탐색 로직은 동작 보존.
+
+### D5. 할당 절감 — B5 해결 (`src/wDom.ts:204-210`, `src/diff.ts:246-292`)
+
+- `getParent: () => nodeParentPointer.value` 노드별 클로저 → 같은 부모의 자식들이
+  **하나의 클로저를 공유** (부모당 1개 생성, 자식들은 같은 참조 할당).
+  `getParent()` 함수 인터페이스는 유지되므로 호출부 변경 없음 → 리스크 최소.
+  필드 직접 참조(`parent` 필드)로의 전환 여부 → **DC-2**.
+- diff 단계 `assign(x, { getParent })` → 직접 대입으로 교체 (함수 호출/객체 리터럴 제거).
+- 무변경 노드 조기 종료: 같은 text·같은 props 참조인 노드의 하위 재귀 생략 여부 → **DC-3**.
+
+### D6. 상수비용 제거 — B6 해결
+
+| 대상 | 현재 | 변경 |
+|---|---|---|
+| `checkVirtualType` (`predicator.ts:96`) | `['f','l'].includes(type)` — 호출마다 배열 할당 | `type === 'f' \|\| type === 'l'` |
+| 이벤트 키 판별 (`render.ts:270,343,367`) | `/^on/` 정규식 | `key[0]==='o' && key[1]==='n'` 문자 비교 |
+| `hasAccessorMethods` (`predicator.ts:131`) | prop마다 `getOwnPropertyDescriptor` | `Map<tagName+key, boolean>` 캐시 |
+| prop 순회 (`render.ts:337,391`) | `Object.entries`/`keys` 배열 생성 | `for-in` 루프 |
+| clear (전량 삭제) | 행마다 `removeChild` + 이벤트 재귀 해제 | 리스트 자식 전부 `D`일 때 부모 일괄 삭제 → **DC-4** |
+
+## 4. 페이즈 구성 (IMPLEMENT.md에서 상세화)
+
+| 페이즈 | 내용 | 종료 게이트 |
+|---|---|---|
+| 1 | D1 + D2 + D4 (Map 매칭, 앵커 개선) | 벤치: replace/append/partial O(n) 확인, 테스트 통과, **br 실측** |
+| 2 | D3 (LIS) — 페이즈 1 크기 실측 후 진입 | 벤치: swap @10k 선형화, br ≤ 5,120B |
+| 3 | D5 + D6 (상수비용) | create/clear 개선 실측, br 재확인 |
+| 4 | 테스트 하드닝 (keyed 이동/정렬/Fragment 혼합 커버리지 보강) | 신규 테스트 통과 |
+| 5 | 통합 검증 (실브라우저 jsfb 하네스, RC-2 수치 판정) | RC-2 달성 여부 보고 |
+
+## 5. RC-2 수치 목표 제안 (jsdom @10k, 기준선 → 목표)
+
+| 시나리오 | 기준선 | 제안 목표 |
+|---|------:|------:|
+| swap 2 rows | 2,719ms | **≤ 100ms** |
+| append 1,000 | 3,031ms | **≤ 200ms** |
+| partial update (1/10) | 700ms | **≤ 300ms** |
+| create 10,000 | 414ms | **≤ 350ms** |
+| clear 10,000 | 90ms | **≤ 50ms** |
+
+> 근거: O(n²) 제거 시 각 시나리오는 create(O(n), 414ms)보다 가벼운 작업이 된다.
+> 실브라우저 최종 판정은 jsfb 하네스의 vanilla 대비 배율로 별도 확인 (1차: react 수준).
+
+## 6. 검증 매핑
+
+- D1/D2/D3 → 기존 keyed 테스트 + 페이즈 4 신규 테스트(swap/역순/부분삭제+삽입 혼합,
+  Fragment 자식 혼합, 중복 key), `bench/bench.mjs` 스케일링 재측정.
+- D4 → Fragment/portal 삽입 테스트 (기존 스위트) + append 벤치.
+- D5 → 전체 테스트 (getParent 의존 경로: `syncAncestorComponentChildren`,
+  `findRealParentElement`, `getElementFromFragment`).
+- D6 → 전체 테스트 + create/clear 벤치. accessor 캐시는 SVG/input 경로 테스트 필수.
+- 크기 → 페이즈 1~3 각각 `min 빌드 br` 실측 기록 (IMPLEMENT.md).
+
+## 7. 열린 결정 (Design Checklist)
+
+- [x] **DC-1**: 이동 마킹 — **기존 `'T'` 재활용, 새 `nr` 코드 추가 안 함**.
+  근거: 새 상수는 render 핸들러 맵·타입 정의까지 연쇄 증가시켜 번들 크기에 불리
+  (2026-07-27 사용자 결정). LIS 밖 노드 = `'T'`(이동), LIS 안 노드 = `'U'`(제자리).
+- [x] **DC-2**: getParent — **클로저 공유안 채택** (부모당 1개, 호출부 무변경).
+  `parent` 필드 직접 참조는 호출부 전면 수정 + 순환 참조 리스크 대비 이득이
+  불분명해 보류. (2026-08-03)
+- [x] **DC-3**: 무변경 노드 조기 종료 — **미도입**. Phase 3 완료 시점에 partial
+  85~122ms로 목표(≤300ms) 대비 충분, 얕은 비교 추가는 코드 증가 대비 이득 불확실.
+  (2026-08-03)
+- [x] **DC-4**: clear 일괄 삭제 — **도입**. 위치는 `findChildWithRemoveElement`
+  (전체 clear는 리스트 'R' 경로로 흐르므로). 안전 조건: 부모의 실제 자식 수 ==
+  삭제 대상 수 && 전부 element/text && portal/HTML 아님. unmount·이벤트 해제는
+  기존 순서 그대로 선행 실행. (2026-08-03)
+
+## 8. 리스크
+
+- R1. LIS 실행 경로에서 `el` 없는 노드(Fragment/빈 노드)가 리스트 자식에 섞이면 anchor
+  계산이 복잡해진다 — `getElementFromFragment` 경로와의 통합 테스트 필수 (페이즈 4).
+- R2. D5의 클로저 공유는 `nodeParentPointer.value`가 노드 생성 후에 채워지는 현재 순서에
+  의존 — 초기화 순서 회귀 테스트 필요.
+- R3. jsdom과 실브라우저의 DOM 조작 비용 비율이 달라 페이즈 5에서 순위가 재편될 수
+  있음 — RC-2 최종 판정은 실브라우저 기준.
+
+## 9. 상태 / 핸드오프
+
+- done: 알고리즘 확정(Map+LIS), D1~D6 상세 설계, 페이즈 구성, RC-2 수치 제안.
+- next: DC-1~DC-4 결정(DC-1은 페이즈 1 착수 전 필수) → IMPLEMENT.md 작성 → 페이즈 1.
+- blockers: DC-1 (구현 착수 전 확정 필요, 나머지는 해당 페이즈 전까지 유예 가능).
+- commit: (문서 커밋 전)

--- a/docs/performance-improvement/IMPLEMENT.md
+++ b/docs/performance-improvement/IMPLEMENT.md
@@ -93,6 +93,16 @@
 | clear 10k | 86.1ms | 정상상태 62~66ms (cold 86~99) | ≤50ms | 미달 — 프로파일상 GC 21%+jsdom 해체 비용 지배, 알고리즘 여지 없음 → P5 실브라우저 판정으로 이관 |
 | min 빌드 br | 4,678B | 4,797B | ≤5,120B | ✅ (여유 323B) |
 
+### 코드 골프 패스 (Phase 3 후속, 동작 불변)
+
+- `insertBefore(el, anchor || null)`로 append/insert 분기 통합, `getElementFromFragment`의
+  내장 virtual 체크 활용, hasLeftNew 루프 → 생성 카운터, clearDiffMeta 일괄화,
+  `updateProps` 중복 비교 제거, `[1,3].includes` → 직접 비교.
+- 죽은 코드 제거: `'L'` RenderType은 chkDiffLoopOrder 삭제 후 부여처가 없어져
+  타입·핸들러·분기(`typeSortedUpdate`/`typeAdd`) 전부 제거.
+- 결과: min gzip 5,205→5,133B(−72B), br 4,797→**4,734B**(−63B, 예산 여유 386B).
+  전체 테스트·정합성·벤치 회귀 없음 (swap 83ms, append 94ms, partial 96ms, create 301ms).
+
 ## Phase 4 — 테스트 하드닝
 
 - [x] 4-1. `src/tests/core-loopMoveOrder.tsx` — 원거리 swap, 역순, 셔플+삽입/삭제 혼합,

--- a/docs/performance-improvement/IMPLEMENT.md
+++ b/docs/performance-improvement/IMPLEMENT.md
@@ -1,0 +1,122 @@
+# IMPLEMENT — Lithent 렌더링 성능 개선
+
+- 작성일: 2026-07-27
+- 상태: **페이즈 1 진행 중**
+- 관련 문서: [REQUIREMENTS.md](./REQUIREMENTS.md), [DESIGN.md](./DESIGN.md)
+
+공통 종료 조건 (모든 페이즈): `pnpm build && pnpm test` 전체 통과 +
+`bench/bench.mjs`·`bench/bench10k.mjs` 재측정 기록 + min 빌드 brotli 실측 기록.
+
+## Phase 1 — Map 매칭 + 앵커 O(1) (D1, D2, D4)
+
+진입: DC-1 확정 완료. / 종료: swap 제외 전 시나리오 O(n) 스케일링 확인.
+
+- [x] 1-1. `diffLoopChildren` Map 기반 재작성 (`src/diff.ts`) — `findSameKeyOriginalItem`·splice 제거
+- [x] 1-2. `chkDiffLoopOrder` O(n) 재작성 (인덱스 Map + 증가 수열 검사, 동작 동일)
+  — 페이즈 2에서 LIS로 대체·삭제됨
+- [x] 1-3. `typeUpdate` 자식 처리에 역순 앵커 사전계산 도입 (`src/render.ts`)
+  — 페이즈 2에서 통합 placement 패스로 대체됨
+- [x] 1-4. 앵커 힌트 전달 경로 — 페이즈 2에서 불필요해져 제거 (updateChildren이 직접 배치)
+- [x] 1-5. 기준 테스트: 전체 통과 (core 43파일/183테스트 포함, 실패 0)
+- [x] 1-6. 벤치 재측정 완료 — swap 제외 전 시나리오 선형화 확인
+- [x] 1-7. br 실측 4,317B (+148B) → 페이즈 2 진입 승인
+
+발견/수정: Phase 1의 앵커 사전계산이 리스트 경계를 넘는 다음 형제(예: 리스트 뒤 footer)를
+무시해 append가 형제 뒤에 삽입되는 버그 유입 → Phase 2 통합 시
+`startFindNextBrotherElement`로 초기 앵커를 잡아 수정. 회귀 방지 테스트는 Phase 4에서 추가.
+
+동작 보존 노트:
+- 중복 key 시 기존은 "남은 것 중 첫 번째 매칭", Map은 "첫 등장만 유지" — 중복 key는
+  정의되지 않은 사용(문서상 금지)이므로 허용. 테스트로 회귀 없음만 확인.
+- diff 단계에서 unused 자식의 `typeDelete`(DOM 제거)가 실행되는 기존 순서 유지.
+
+### 측정 기록 (Phase 1)
+
+| 항목 | before | after P1 |
+|---|---|---|
+| replace 4k (jsdom) | 878.7ms | 183.6ms |
+| append 1k→10k | 3,031ms | 109.9ms |
+| partial 1/10 @10k | 700ms | 120ms |
+| swap @10k (참고, P2 대상) | 2,719ms | 186.1ms |
+| min 빌드 br | 4,169B | 4,317B |
+
+## Phase 2 — LIS 최소 이동 (D3)
+
+진입: Phase 1 br 실측 후 예산 확인. / 종료: swap @10k ≤ 100ms (RC-2).
+
+- [x] 2-1. `getLisPositions`(이진 탐색 LIS) 추가, oldIndex(`oi`)를 D1 매칭에서 기록
+- [x] 2-2. `chkDiffLoopOrder` 삭제 — `'L'` 타입은 더 이상 부여되지 않음 (DC-1: 'T' 재활용)
+- [x] 2-3. `updateChildren` 통합 알고리즘: LTR 콘텐츠 패스(라이프사이클 순서 보존,
+  신규는 생성만) → LIS로 제자리 노드 선별 → RTL placement 패스(신규+비LIS 이동만 삽입).
+  꼬리 연속 신규 run은 appendChild fast path (jsdom insertBefore가 O(위치)라 실측 왜곡 +
+  실브라우저에도 이득). 이동 없는 경우 placement 스캔 생략.
+- [x] 2-4. 정합성 검증: 스크래치 verify-order.mjs — swap/역순/셔플×5/중간삽입/산발삭제/
+  clear/재충전 + 리스트 경계(footer) 침범 검사 전부 통과. 전체 테스트 통과.
+- [x] 2-5. 벤치 + br 실측 — 아래 표. 예산 내로 LIS 확정 (폴백 불필요).
+
+### 측정 기록 (Phase 2)
+
+| 항목 | 기준선 | after P2 | RC-2 목표 | 판정 |
+|---|---:|---:|---:|---|
+| swap 2 @10k | 2,719ms | 97.2ms | ≤100ms | ✅ |
+| append 1k→10k | 3,031ms | 108.7ms | ≤200ms | ✅ |
+| partial 1/10 @10k | 700ms | 128.7ms | ≤300ms | ✅ |
+| create 10k | 414ms | 435.7ms | ≤350ms | P3 대상 |
+| clear 10k | 90ms | 86.1ms | ≤50ms | P3 대상 |
+| min 빌드 br | 4,169B | 4,678B | ≤5,120B | ✅ (여유 442B) |
+
+## Phase 3 — 할당·상수비용 절감 (D5, D6)
+
+진입: DC-2·DC-3·DC-4 결정. / 종료: create/clear 개선 실측 (RC-2: create ≤ 350ms, clear ≤ 50ms).
+
+- [x] 3-1. `getParent` 클로저 공유화 — h()단계(`wDom.ts`)·diff단계 3개소 모두 부모당 1개로
+- [x] 3-2. `checkVirtualType` 문자 비교화, `/^on/`·prop 순회를 문자비교+for-in으로
+  (render.ts의 `entries`/`keys` 의존 제거)
+- [x] 3-3. `hasAccessorMethods` — nodeName+key 캐시 (HTML 대문자/SVG 소문자라 충돌 없음)
+- [x] 3-4. clear 일괄 삭제 (DC-4) — `findChildWithRemoveElement`에 bulk fast path.
+  주의 2가지: ① 전체 clear는 keyed 경로가 아닌 리스트 'R' 경로로 흐르므로 bulk는
+  `typeDeleteUnused`가 아닌 여기 위치해야 함. ② jsdom에서 `parent.childNodes` 접근은
+  live NodeList를 만들어 이후 모든 DOM 변형을 느리게 함(벤치 오염) —
+  `firstChild`/`nextSibling` 포인터 순회로 카운트할 것.
+- [x] 3-5. 전체 테스트 통과 + 벤치 + br 실측 (아래)
+- 추가 발견: `wDomChildrenToDom`이 부모 노드마다 중간 DocumentFragment를 생성
+  (10k행 create 시 ~4만 개) → 직접 appendChild로 교체, create 433→~300ms.
+
+### 측정 기록 (Phase 3)
+
+| 항목 | after P2 | after P3 | RC-2 목표 | 판정 |
+|---|---:|---:|---:|---|
+| create 10k | 435.7ms | 283~317ms | ≤350ms | ✅ |
+| partial 1/10 @10k | 128.7ms | 85~122ms | ≤300ms | ✅ |
+| swap 2 @10k | 97.2ms | 77~108ms (편차 큼) | ≤100ms | 경계 — P5 실브라우저 판정 |
+| append 1k→10k | 108.7ms | 90~117ms | ≤200ms | ✅ |
+| clear 10k | 86.1ms | 정상상태 62~66ms (cold 86~99) | ≤50ms | 미달 — 프로파일상 GC 21%+jsdom 해체 비용 지배, 알고리즘 여지 없음 → P5 실브라우저 판정으로 이관 |
+| min 빌드 br | 4,678B | 4,797B | ≤5,120B | ✅ (여유 323B) |
+
+## Phase 4 — 테스트 하드닝
+
+- [x] 4-1. `src/tests/core-loopMoveOrder.tsx` — 원거리 swap, 역순, 셔플+삽입/삭제 혼합,
+  append, prepend/중간삽입, 전체 clear, 재충전 (8 케이스)
+- [x] 4-2. 경계 테스트 — 리스트 뒤 형제(`li.tail`) 침범 검증을 모든 케이스에 포함
+  (Phase 1에서 유입됐던 경계 버그의 회귀 방지). 중복 key는 정의되지 않은 사용으로 제외.
+- [x] 4-3. `src/tests/core-loopLifecycleOrder.tsx` — 초기/삽입 mount LTR 순서,
+  이동 시 재마운트 없음, 삭제 시 unmount 순서 (4 케이스)
+- [x] 4-4. 전체 통과: core 45파일/195테스트 (신규 12개 포함)
+
+## Phase 5 — 통합 검증 (실브라우저)
+
+- [ ] 5-1. js-framework-benchmark 하네스에 lithent keyed 구현 작성 (로컬 실행)
+- [ ] 5-2. keyed 시나리오 측정 → react·preact와 비교표 작성
+- [ ] 5-3. RC-2 달성 판정 및 REQUIREMENTS.md 상태 갱신
+- [ ] 5-4. MANUAL_TEST_CHECKLIST.md 작성 및 수행
+
+## 상태 / 핸드오프
+
+- done: Phase 1~4 완료. keyed diff Map+LIS(oi 기록→`updateChildren` 통합 배치),
+  클로저 공유·for-in·accessor 캐시·DF 제거·clear bulk. 전체 195테스트 통과,
+  br 4,797B(예산 내). 회귀 테스트 12개 추가. MANUAL_TEST_CHECKLIST.md 작성.
+- next: Phase 5 — js-framework-benchmark 하네스 실브라우저 측정 (5-1~5-4),
+  swap·clear 최종 판정. 이후 문서·코드 커밋.
+- blockers: 없음. (jsdom 벤치의 swap 편차·clear 미달은 실브라우저 판정으로 이관)
+- commit: (커밋 전 — 작업 트리에 src/diff.ts, src/render.ts, src/wDom.ts,
+  src/types/index.ts, src/utils/predicator.ts, src/tests/ 신규 2파일, docs/ 변경 있음)

--- a/docs/performance-improvement/MANUAL_TEST_CHECKLIST.md
+++ b/docs/performance-improvement/MANUAL_TEST_CHECKLIST.md
@@ -1,0 +1,44 @@
+# MANUAL_TEST_CHECKLIST — 렌더링 성능 개선 릴리스 전 수동 확인
+
+- 작성일: 2026-08-03
+- 대상: `feat/alterSpeed` 브랜치 (keyed diff Map+LIS, 렌더 배치 재작성, 할당·상수비용 절감)
+- 사전 조건: `pnpm build && pnpm test` 전체 통과 상태에서 수행
+
+## A. 자동 검증 재확인 (릴리스 직전 1회)
+
+- [ ] A-1. `pnpm build && pnpm test` 전체 통과 (0 실패)
+- [ ] A-2. `node docs/performance-improvement/bench/verify-order.mjs` → ALL PASS
+- [ ] A-3. `node docs/performance-improvement/bench/bench10k.mjs` → RC-2 수치 회귀 없음
+- [ ] A-4. min 빌드 brotli ≤ 5,120B
+  (`node -e` zlib.brotliCompressSync on dist/lithent.umd.js)
+
+## B. 예제/문서 앱 육안 확인 (실브라우저)
+
+- [ ] B-1. `pnpm dev` (html/portal.html) — portal 데모가 지정 위치에 렌더되고
+  버튼 인터랙션 후에도 위치·내용 정상
+- [ ] B-2. `pnpm dev:examples` — 예제 전반 클릭/입력 인터랙션 정상,
+  콘솔 에러 0건
+- [ ] B-3. `pnpm dev:docs` — 문서 사이트 페이지 이동·코드 데모 정상
+- [ ] B-4. 리스트 데모에서 추가/삭제/정렬 반복 후 DOM 순서가 데이터와 일치
+  (개발자 도구로 실제 노드 순서 확인)
+
+## C. SSR / Hydration
+
+- [ ] C-1. createLithent 보일러플레이트(또는 ssr 예제)로 SSR 페이지 생성 →
+  hydration 후 이벤트 동작 확인 (재렌더 없이 인터랙티브해지는지)
+- [ ] C-2. hydration 후 keyed 리스트 갱신(추가/삭제/정렬)이 정상 동작
+
+## D. 실브라우저 성능 판정 (Phase 5, RC-2 최종)
+
+- [ ] D-1. js-framework-benchmark 하네스에 lithent keyed 구현 추가, 로컬 실행
+- [ ] D-2. keyed 시나리오(create 1k/10k, replace, partial, select, swap,
+  remove, append, clear) 측정값 기록
+- [ ] D-3. 동일 머신에서 react·preact와 비교표 작성 — 1차 목표: react 수준
+- [ ] D-4. swap·clear의 jsdom 경계/미달 항목이 실브라우저에서 목표 충족하는지 판정
+- [ ] D-5. 결과를 REQUIREMENTS.md §8 상태와 IMPLEMENT.md Phase 5에 기록
+
+## 통과 기준
+
+- A·B·C 전 항목 체크 + 콘솔 에러 0건.
+- D는 측정·기록 완료가 기준 (수치 미달 시 릴리스 보류가 아니라
+  REQUIREMENTS.md RC-2 재협의 대상).

--- a/docs/performance-improvement/REQUIREMENTS.md
+++ b/docs/performance-improvement/REQUIREMENTS.md
@@ -1,0 +1,122 @@
+# REQUIREMENTS — Lithent 렌더링 성능 개선
+
+- 브랜치: `feat/alterSpeed`
+- 작성일: 2026-07-27 (최종 수정: 2026-07-27)
+- 상태: **병목 분석 완료 — RC-2/RC-3 결정 대기**
+- 관련 문서: [BOTTLENECK_ANALYSIS.md](./BOTTLENECK_ANALYSIS.md) → DESIGN.md (예정) → IMPLEMENT.md (예정) → MANUAL_TEST_CHECKLIST.md (예정)
+
+## 1. 배경 및 목적
+
+Lithent는 diff 시 최적화 알고리즘 없이 트리를 정직하게 전부 비교하는 구조라서
+[js-framework-benchmark](https://github.com/krausest/js-framework-benchmark)(keyed)로
+측정하면 성능 지표가 잘 나오지 않는다.
+**이번 작업의 목적은 기존 동작을 그대로 유지하면서 js-framework-benchmark에서
+좋은 성능 지표를 얻는 것**이다.
+
+병목은 코드 분석 + jsdom 마이크로벤치 실측으로 확인 완료 —
+상세는 [BOTTLENECK_ANALYSIS.md](./BOTTLENECK_ANALYSIS.md) 참조. 요약:
+
+| 순위 | 병목 | 실측 근거 (10k행, jsdom) |
+|---|---|---|
+| B1 | 순서 변경 시 전 행 DOM 재삽입 (`render.ts` T-경로) | swap 2rows = **2,719ms** |
+| B2 | 신규 노드 삽입 위치 탐색 O(n²) (`startFindNextBrotherElement`) | append 1k = **3,031ms** |
+| B3 | keyed 키 매칭 O(n²) (`findSameKeyOriginalItem` + splice) | replace 4k = 879ms (2배당 ×3.4) |
+| B4 | `chkDiffLoopOrder` O(n²) — keyed 갱신마다 실행 | 부분갱신 4k = 380ms (2배당 ×4) |
+| B5 | 전체 리스트 재-diff + 노드당 클로저 2회 할당 | partial 1/10 of 10k = 700ms |
+| B6 | prop 처리 상수비용 (정규식/디스크립터/배열 할당) | create 10k = 414ms, clear = 90ms |
+
+## 2. 목표
+
+- G1. js-framework-benchmark(keyed) 주요 시나리오에서 O(n²) 경로를 제거한다:
+  swap / append / replace all / partial update가 리스트 크기에 선형(또는 n log n)으로 스케일.
+- G2. 모든 최적화는 **벤치마크 전/후 실측 수치로 입증**한다.
+- G3. 기존 동작(렌더 결과, 라이프사이클 순서, 공개 API)을 100% 유지한다.
+  기존 전체 테스트(`pnpm build && pnpm test`) 통과가 필수 조건.
+- G4. 코어 번들 크기: **최소화(minified) 빌드 brotli 기준 5KB 이하 유지** (RC-3 확정).
+  - 크기 기준선 (2026-07-27 실측, zlib brotli 기본 옵션):
+
+    | 파일 | raw | gzip | brotli |
+    |---|---:|---:|---:|
+    | lithent.umd.js (minified) | 11,309B | 4,510B | **4,169B** |
+    | lithent.mjs (비압축최적화) | 15,983B | 5,076B | 4,626B |
+    | preact 10.29.7 min (참고) | 11,360B | 4,839B | 4,410B |
+
+  - 유효 예산: 4,169B → 5,120B, **여유 +951B (br)**.
+  - 스트레치 목표: preact min(4,410B br)보다 작게 유지.
+
+### 정량 기준선 (jsdom, 10k행 — 개선 목표는 RC-2에서 확정)
+
+| 시나리오 | 기준선 | 목표 |
+|---|------:|---|
+| swap 2 rows | 2,719ms | O(n) 스케일링 달성 (수치 목표 `TBD RC-2`) |
+| append 1,000 rows | 3,031ms | 〃 |
+| partial update (1/10) | 700ms | 〃 |
+| create 10,000 rows | 414ms | 상수비용 절감 (`TBD RC-2`) |
+
+## 3. 범위
+
+### 포함 (확정 — RC-1 결정 완료)
+
+- S1. 성능 계측 수단: js-framework-benchmark 시나리오 재현 벤치 스크립트를 저장소에 추가.
+- S2. keyed 리스트 diff 최적화 (B3, B4) — Map 기반 O(n) 키 매칭.
+- S3. 렌더 경로 최적화 (B1, B2) — 삽입 위치 탐색 O(1)화, LIS 기반 최소 이동.
+- S4. 할당 절감 (B5) — 클로저/assign 감소, 무변경 노드 조기 종료.
+- S5. 상수비용 최적화 (B6) — 정규식/디스크립터 조회/배열 할당 제거, clear 일괄 삭제.
+- S6. 변경 전후 동등성 검증: 기존 전체 테스트 통과 + 필요 시 keyed 시나리오 테스트 보강.
+
+### 비범위 (Non-goals)
+
+- N1. 공개 API 변경·추가 (`h`, `mount`, `lmount`, `render`, `portal`, `Fragment` 등 시그니처 불변).
+- N2. helper / ssr / tag / ftags 패키지의 직접 수정 (코어 개선의 파급 효과는 허용).
+- N3. 스케줄링/배칭 등 새 렌더링 모델 도입 (기존 microtask 배칭 유지).
+- N4. js-framework-benchmark 공식 저장소 등재 작업 자체 (측정용 구현 작성은 S1 범위).
+
+## 4. 제약
+
+- C1. 패키지 매니저는 pnpm, 전체 테스트는 빌드 후 실행 (`pnpm build` → `pnpm test`).
+- C2. WDom 노드의 `props`/`children` **배열·객체 참조 안정성**을 깨면 안 된다
+  — 조상/클로저가 같은 배열 인스턴스를 공유 (`src/diff.ts:184-190` 주석 참조).
+- C3. `nr`, `oc`, `op` 등 short-key 메타데이터 규약 유지 (번들 크기 사유).
+- C4. Fragment / portal / hydration 경로의 동작 보존 (SSR 패키지가 코어에 의존).
+- C5. `renew()`의 microtask 배칭(`queueMicrotask`, `src/utils/redraw.ts`) 동작 유지.
+- C6. TypeScript strict 모드, 기존 ESLint/Prettier 규칙 준수.
+
+## 5. 가정
+
+- A1. jsdom 마이크로벤치의 절대값은 실브라우저와 다르지만 스케일링 특성·병목 순위는 동일하다.
+  최종 지표 확인은 실브라우저(js-framework-benchmark 하네스)로 수행한다.
+- A2. 기존 테스트 스위트가 렌더 결과 동등성의 1차 안전망이다.
+  keyed 정렬/이동 경로는 커버리지 보강이 선행될 수 있다 (DESIGN.md에서 판단).
+- A3. dist 빌드는 현재 src와 동기화된 상태로 측정되었다 (클린 워킹트리).
+
+## 6. 검증 요구사항
+
+- V1. 모든 최적화 단계는 벤치 전/후 수치를 IMPLEMENT.md에 기록한다.
+- V2. `pnpm build && pnpm test` 전체 통과가 각 단계(phase)의 종료 조건이다.
+- V3. 번들 크기(gzip)는 각 단계 종료 시 측정해 기준선과 비교 기록한다.
+- V4. 최종 검증은 js-framework-benchmark 하네스(실브라우저)로 keyed 시나리오를 측정한다.
+- V5. 릴리스 전 수동 확인 항목은 MANUAL_TEST_CHECKLIST.md에서 관리한다.
+
+## 7. 결정 기록 (Requirements Checklist)
+
+- [x] **RC-1**: 범위 — 렌더 경로(S3)·할당 절감(S4)·diff 구조 개선 **모두 포함**.
+  근거: 실측 결과 최대 병목(swap 2.7s, append 3.0s)이 diff가 아닌 렌더 경로에 있어
+  diff만 고쳐서는 jsfb 지표가 나오지 않음. (2026-07-27 사용자 결정)
+- [x] **RC-4**: 벤치마크 — **js-framework-benchmark 시나리오 기준**.
+  개발 중에는 저장소 내 재현 스크립트(jsdom)로 회귀 측정, 최종은 실브라우저 하네스.
+  근거: 사용자 목적 자체가 jsfb 지표 개선. (2026-07-27 사용자 결정)
+- [x] **RC-3**: 번들 크기 상한 — **minified 빌드 brotli ≤ 5KB** (스트레치: preact min 4,410B br 이하).
+  근거: 실측상 현재 min 빌드는 4,169B br로 preact보다 작음. 풀 최적화(LIS 포함)의
+  순증 예상은 +200~500B br(제거되는 O(n²) 코드로 일부 상쇄)로 예산 내 수용 가능.
+  (2026-07-27 사용자 결정)
+- [x] **RC-2**: 정량 목표 — DESIGN.md §5 제안 수치로 확정 (2026-07-27):
+  jsdom @10k 기준 swap ≤ 100ms, append 1k ≤ 200ms, partial(1/10) ≤ 300ms,
+  create ≤ 350ms, clear ≤ 50ms. 실브라우저 1차 목표는 react 수준, 2차 preact 근접.
+
+## 8. 상태 / 핸드오프
+
+- done: 병목 분석 (B1~B6 실측), RC-1·RC-3·RC-4 결정, 크기 기준선 실측
+  (lithent min 4,169B br vs preact 4,410B br), DESIGN.md 초안 (Map+LIS 채택, D1~D6).
+- next: RC-2 수치 확정 (DESIGN.md §5 제안 검토) → DC-1~DC-4 결정 → IMPLEMENT.md.
+- blockers: DC-1(이동 마킹 방식)은 구현 착수 전 확정 필요.
+- commit: (문서 커밋 전)

--- a/docs/performance-improvement/bench/bench.mjs
+++ b/docs/performance-improvement/bench/bench.mjs
@@ -1,0 +1,102 @@
+// Micro-benchmark: js-framework-benchmark 스타일 시나리오로 lithent diff/render 스케일링 측정
+import { createRequire } from 'module';
+const require = createRequire('/Users/n250109005/project/lithent/package.json');
+const { JSDOM } = require('jsdom');
+
+const dom = new JSDOM(
+  '<!DOCTYPE html><html><body><div id="root"></div></body></html>'
+);
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+globalThis.DocumentFragment = dom.window.DocumentFragment;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.Element = dom.window.Element;
+globalThis.Text = dom.window.Text;
+globalThis.Node = dom.window.Node;
+
+const { h, mount, render } = await import(
+  '/Users/n250109005/project/lithent/dist/lithent.mjs'
+);
+
+let idCounter = 1;
+const buildData = n =>
+  Array.from({ length: n }, () => ({
+    id: idCounter++,
+    label: 'row label ' + Math.random().toString(36).slice(2, 8),
+  }));
+
+let data = [];
+let renewFn;
+
+const App = mount(renew => {
+  renewFn = renew;
+  return () =>
+    h(
+      'table',
+      {},
+      data.map(item =>
+        h(
+          'tr',
+          { key: item.id, class: 'row' },
+          h('td', { class: 'col-md-1' }, String(item.id)),
+          h('td', { class: 'col-md-4' }, h('a', {}, item.label)),
+          h('td', { class: 'col-md-6' }, 'x')
+        )
+      )
+    );
+});
+
+render(h(App, {}), document.getElementById('root'));
+
+// renew()는 queueMicrotask로 배칭되므로 microtask flush 후 측정 종료
+const ms = async fn => {
+  const t0 = performance.now();
+  fn();
+  await Promise.resolve();
+  return performance.now() - t0;
+};
+
+const rowCount = () => document.querySelectorAll('tr').length;
+
+const run = async n => {
+  const r = {};
+  data = [];
+  renewFn();
+  await Promise.resolve();
+
+  r.create = await ms(() => { data = buildData(n); renewFn(); });
+  if (rowCount() !== n) throw Error(`create failed: ${rowCount()} !== ${n}`);
+
+  r.updateEvery10th = await ms(() => {
+    data.forEach((item, i) => { if (i % 10 === 0) item.label += ' !!!'; });
+    renewFn();
+  });
+
+  r.swap = await ms(() => {
+    const tmp = data[1]; data[1] = data[data.length - 2]; data[data.length - 2] = tmp;
+    renewFn();
+  });
+
+  r.replaceAll = await ms(() => { data = buildData(n); renewFn(); });
+  if (rowCount() !== n) throw Error(`replace failed: ${rowCount()} !== ${n}`);
+
+  r.append = await ms(() => { data = data.concat(buildData(Math.floor(n / 10))); renewFn(); });
+  r.clear = await ms(() => { data = []; renewFn(); });
+  if (rowCount() !== 0) throw Error(`clear failed: ${rowCount()} !== 0`);
+  return r;
+};
+
+await run(200); // warmup
+
+const sizes = [500, 1000, 2000, 4000];
+const results = [];
+for (const n of sizes) results.push({ n, ...(await run(n)) });
+
+console.log('N\tcreate\tupd10th\tswap\treplace\tappend10%\tclear');
+for (const r of results) {
+  console.log(
+    [r.n, r.create, r.updateEvery10th, r.swap, r.replaceAll, r.append, r.clear]
+      .map(v => (typeof v === 'number' ? v.toFixed(1) : v))
+      .join('\t')
+  );
+}

--- a/docs/performance-improvement/bench/bench10k.mjs
+++ b/docs/performance-improvement/bench/bench10k.mjs
@@ -1,0 +1,23 @@
+import { createRequire } from 'module';
+const require = createRequire('/Users/n250109005/project/lithent/package.json');
+const { JSDOM } = require('jsdom');
+const dom = new JSDOM('<!DOCTYPE html><html><body><div id="root"></div></body></html>');
+globalThis.window = dom.window; globalThis.document = dom.window.document;
+globalThis.DocumentFragment = dom.window.DocumentFragment;
+globalThis.HTMLElement = dom.window.HTMLElement; globalThis.Element = dom.window.Element;
+globalThis.Text = dom.window.Text; globalThis.Node = dom.window.Node;
+const { h, mount, render } = await import('/Users/n250109005/project/lithent/dist/lithent.mjs');
+let idCounter = 1;
+const buildData = n => Array.from({ length: n }, () => ({ id: idCounter++, label: 'row ' + Math.random().toString(36).slice(2, 8) }));
+let data = []; let renewFn;
+const App = mount(renew => { renewFn = renew; return () => h('table', {}, data.map(item => h('tr', { key: item.id, class: 'row' }, h('td', { class: 'col-md-1' }, String(item.id)), h('td', { class: 'col-md-4' }, h('a', {}, item.label)), h('td', { class: 'col-md-6' }, 'x')))); });
+render(h(App, {}), document.getElementById('root'));
+const ms = async fn => { const t0 = performance.now(); fn(); await Promise.resolve(); return performance.now() - t0; };
+// warmup
+data = buildData(200); renewFn(); await Promise.resolve(); data = []; renewFn(); await Promise.resolve();
+const create10k = await ms(() => { data = buildData(10000); renewFn(); });
+const upd = await ms(() => { data.forEach((it, i) => { if (i % 10 === 0) it.label += ' !!!'; }); renewFn(); });
+const swap = await ms(() => { const t = data[1]; data[1] = data[998]; data[998] = t; renewFn(); });
+const append1k = await ms(() => { data = data.concat(buildData(1000)); renewFn(); });
+const clear = await ms(() => { data = []; renewFn(); });
+console.log(JSON.stringify({ create10k, updateEvery10thOf10k: upd, swap2of10k: swap, append1kTo10k: append1k, clear10k: clear }, (k,v) => typeof v === 'number' ? +v.toFixed(1) : v));

--- a/docs/performance-improvement/bench/verify-order.mjs
+++ b/docs/performance-improvement/bench/verify-order.mjs
@@ -1,0 +1,136 @@
+// DOM 순서 정합성 검증: keyed 리스트의 다양한 변형 후 실제 DOM 순서가 데이터와 일치하는지 확인
+// 실행: node docs/performance-improvement/bench/verify-order.mjs (저장소 루트에서)
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const require = createRequire(root + '/package.json');
+const { JSDOM } = require('jsdom');
+
+const dom = new JSDOM(
+  '<!DOCTYPE html><html><body><div id="root"></div></body></html>'
+);
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+globalThis.DocumentFragment = dom.window.DocumentFragment;
+globalThis.HTMLElement = dom.window.HTMLElement;
+globalThis.Element = dom.window.Element;
+globalThis.Text = dom.window.Text;
+globalThis.Node = dom.window.Node;
+
+const { h, mount, render } = await import(root + '/dist/lithent.mjs');
+
+let data = [];
+let renewFn;
+let failures = 0;
+
+const App = mount(renew => {
+  renewFn = renew;
+  return () =>
+    h(
+      'div',
+      {},
+      h(
+        'ul',
+        {},
+        data.map(item => h('li', { key: item.id }, String(item.id)))
+      ),
+      h('footer', {}, 'FOOTER')
+    );
+});
+
+render(h(App, {}), document.getElementById('root'));
+
+const flush = () => Promise.resolve();
+
+const assertOrder = async name => {
+  renewFn();
+  await flush();
+  const actual = [...document.querySelectorAll('li')].map(li => li.textContent);
+  const expected = data.map(d => String(d.id));
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  // footer가 ul 밖에서 li 뒤에 오는지 (리스트 경계 침범 검증)
+  const ul = document.querySelector('ul');
+  const boundary =
+    ul.querySelector('footer') === null &&
+    ul.nextElementSibling?.tagName === 'FOOTER' &&
+    [...ul.children].every(c => c.tagName === 'LI');
+  if (!ok || !boundary) {
+    failures++;
+    console.log(`FAIL ${name}`);
+    if (!ok)
+      console.log(
+        '  expected',
+        expected.join(','),
+        '\n  actual  ',
+        actual.join(',')
+      );
+    if (!boundary) console.log('  boundary violated: footer/ul mixing');
+  } else {
+    console.log(`ok   ${name}`);
+  }
+};
+
+const set = ids => {
+  data = ids.map(id => ({ id }));
+};
+
+set([1, 2, 3, 4, 5]);
+await assertOrder('initial 1-5');
+
+set([1, 4, 3, 2, 5]);
+await assertOrder('swap 2<->4');
+
+set([5, 4, 3, 2, 1]);
+await assertOrder('reverse');
+
+set([3, 1, 4, 1.5, 5, 9, 2, 6]);
+await assertOrder('shuffle + add + remove');
+
+set([3, 1, 4, 1.5, 5, 9, 2, 6, 10, 11]);
+await assertOrder('append 2 at end');
+
+set([0, 3, 1, 4, 1.5, 5, 9, 2, 6, 10, 11]);
+await assertOrder('prepend 1');
+
+set([0, 3, 1, 99, 4, 1.5, 5, 9, 2, 6, 10, 11]);
+await assertOrder('insert middle');
+
+set([0, 3, 99, 4, 5, 9, 6, 10, 11]);
+await assertOrder('remove scattered');
+
+set([]);
+await assertOrder('clear');
+
+set([7, 8, 9]);
+await assertOrder('refill after clear');
+
+set([9, 7, 8]);
+await assertOrder('rotate');
+
+set([20, 9, 21, 7, 22, 8, 23]);
+await assertOrder('interleave new');
+
+const N = 500;
+set(Array.from({ length: N }, (_, i) => i));
+await assertOrder('bulk init 500');
+for (let round = 0; round < 5; round++) {
+  const arr = data.map(d => d.id);
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  const kept = arr.slice(0, 450);
+  kept.splice(100, 0, 1000 + round * 10, 1001 + round * 10);
+  set(kept);
+  await assertOrder(`random shuffle round ${round}`);
+}
+
+set([]);
+await assertOrder('clear after shuffles');
+set([1, 2, 3]);
+await assertOrder('refill again');
+
+console.log(failures ? `\n${failures} FAILURES` : '\nALL PASS');
+process.exit(failures ? 1 : 0);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,7 +131,7 @@ importers:
         version: 9.16.0
       '@lithent/lithent-vite':
         specifier: ^0.3.3
-        version: 0.3.3(lithent@1.21.3)(vite@5.4.8(@types/node@20.19.25)(lightningcss@1.30.1)(terser@5.18.1))
+        version: 0.3.3(lithent@1.21.7)(vite@5.4.8(@types/node@20.19.25)(lightningcss@1.30.1)(terser@5.18.1))
       '@tailwindcss/postcss':
         specifier: ^4.0.0
         version: 4.1.14
@@ -151,8 +151,8 @@ importers:
         specifier: ^9.1.0
         version: 9.1.0(eslint@9.16.0(jiti@2.6.1))
       lithent:
-        specifier: ^1.21.3
-        version: 1.21.3
+        specifier: ^1.21.7
+        version: 1.21.7
       postcss:
         specifier: ^8.4.24
         version: 8.4.47
@@ -184,18 +184,18 @@ importers:
         specifier: ^4.21.1
         version: 4.21.1
       lithent:
-        specifier: ^1.21.3
-        version: 1.21.3
+        specifier: ^1.21.7
+        version: 1.21.7
       state-ref:
         specifier: ^2.0.0
         version: 2.0.0
     devDependencies:
       '@lithent/lithent-mdx':
         specifier: ^0.2.6
-        version: 0.2.6(lithent@1.21.3)(rollup@4.24.0)(vite@5.4.8(@types/node@22.9.0)(lightningcss@1.30.1)(terser@5.18.1))
+        version: 0.2.6(acorn@8.14.0)(lithent@1.21.7)(rollup@4.24.0)(vite@5.4.8(@types/node@22.9.0)(lightningcss@1.30.1)(terser@5.18.1))
       '@lithent/lithent-vite':
         specifier: ^0.3.3
-        version: 0.3.3(lithent@1.21.3)(vite@5.4.8(@types/node@22.9.0)(lightningcss@1.30.1)(terser@5.18.1))
+        version: 0.3.3(lithent@1.21.7)(vite@5.4.8(@types/node@22.9.0)(lightningcss@1.30.1)(terser@5.18.1))
       '@tailwindcss/postcss':
         specifier: ^4.0.0
         version: 4.1.14
@@ -2717,8 +2717,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  lithent@1.21.3:
-    resolution: {integrity: sha512-2TpIdUfALmQKEupFudKpkITbp2qkXL/03LkIOiVgXVhW98KmspsoiiP8q6mp+fUU/fVuj2BJr3Qt/gG8/rrm0A==}
+  lithent@1.21.7:
+    resolution: {integrity: sha512-o93x4xdGxVmCecBWgR1TB2GHiNx8kzDtdcjRxESOjyKAUOulZFHLPehMJwVVsqvya3g+ijDRxQSnOxcTpTsVww==}
 
   local-pkg@0.5.1:
     resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
@@ -4461,10 +4461,10 @@ snapshots:
       '@babel/types': 7.28.5
       magic-string: 0.30.19
 
-  '@lithent/lithent-mdx@0.2.6(lithent@1.21.3)(rollup@4.24.0)(vite@5.4.8(@types/node@22.9.0)(lightningcss@1.30.1)(terser@5.18.1))':
+  '@lithent/lithent-mdx@0.2.6(acorn@8.14.0)(lithent@1.21.7)(rollup@4.24.0)(vite@5.4.8(@types/node@22.9.0)(lightningcss@1.30.1)(terser@5.18.1))':
     dependencies:
       '@mdx-js/rollup': 3.1.0(acorn@8.14.0)(rollup@4.24.0)
-      lithent: 1.21.3
+      lithent: 1.21.7
       vite: 5.4.8(@types/node@22.9.0)(lightningcss@1.30.1)(terser@5.18.1)
     transitivePeerDependencies:
       - acorn
@@ -4485,18 +4485,18 @@ snapshots:
       '@lithent/lithent-template-parser': 0.1.0
       vite: 5.4.8(@types/node@22.9.0)(lightningcss@1.30.1)(terser@5.18.1)
 
-  '@lithent/lithent-vite@0.3.3(lithent@1.21.3)(vite@5.4.8(@types/node@20.19.25)(lightningcss@1.30.1)(terser@5.18.1))':
+  '@lithent/lithent-vite@0.3.3(lithent@1.21.7)(vite@5.4.8(@types/node@20.19.25)(lightningcss@1.30.1)(terser@5.18.1))':
     dependencies:
       '@lithent/hmr-parser': 0.2.2
       '@lithent/lithent-template-vite': 0.1.0(vite@5.4.8(@types/node@20.19.25)(lightningcss@1.30.1)(terser@5.18.1))
-      lithent: 1.21.3
+      lithent: 1.21.7
       vite: 5.4.8(@types/node@20.19.25)(lightningcss@1.30.1)(terser@5.18.1)
 
-  '@lithent/lithent-vite@0.3.3(lithent@1.21.3)(vite@5.4.8(@types/node@22.9.0)(lightningcss@1.30.1)(terser@5.18.1))':
+  '@lithent/lithent-vite@0.3.3(lithent@1.21.7)(vite@5.4.8(@types/node@22.9.0)(lightningcss@1.30.1)(terser@5.18.1))':
     dependencies:
       '@lithent/hmr-parser': 0.2.2
       '@lithent/lithent-template-vite': 0.1.0(vite@5.4.8(@types/node@22.9.0)(lightningcss@1.30.1)(terser@5.18.1))
-      lithent: 1.21.3
+      lithent: 1.21.7
       vite: 5.4.8(@types/node@22.9.0)(lightningcss@1.30.1)(terser@5.18.1)
 
   '@mdx-js/mdx@3.1.0(acorn@8.14.0)':
@@ -6610,7 +6610,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  lithent@1.21.3: {}
+  lithent@1.21.7: {}
 
   local-pkg@0.5.1:
     dependencies:

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,7 +1,7 @@
 import { WDom, TagFunctionResolver, RenderType, Props } from '@/types';
 import { checkCustemComponentFunction, getKey } from '@/utils/predicator';
 import { getParent } from '@/utils';
-import { typeDelete, recursiveRemoveEvent } from '@/render';
+import { typeDeleteUnused, recursiveRemoveEvent } from '@/render';
 import {
   checkEmptyElement,
   checkSameWDomWithOriginal,
@@ -10,7 +10,7 @@ import {
 } from '@/utils/predicator';
 
 import { runUnmountQueueFromWDom } from '@/hook/internal/unmount';
-import { assign, keys, entries } from '@/utils';
+import { keys, entries } from '@/utils';
 
 /**
  * The starting point of the diffing process between the original virtual DOM and the new virtual DOM for re-rendering.
@@ -111,54 +111,7 @@ const addReRenderTypeProperty = (
   const isKeyChecked =
     !newWDom.isRoot && parent && parent.type === 'l' && checkExistyKey(newWDom);
 
-  let result: RenderType = isSameType
-    ? isKeyChecked
-      ? 'T'
-      : 'U'
-    : isKeyChecked
-      ? 'S'
-      : 'R';
-
-  if (
-    newWDom.type === 'l' &&
-    result === 'U' &&
-    originalWDom &&
-    chkDiffLoopOrder(newWDom, originalWDom)
-  ) {
-    result = 'L';
-  }
-
-  return result;
-};
-
-/**
- * Check if a reverse order swap is needed when updating keyed loop-type elements.
- */
-const chkDiffLoopOrder = (newWDom: WDom, originalWDom: WDom) => {
-  // Fast exit: no keys to compare
-  if (
-    !checkExistyKey((newWDom.children || [])[0]) ||
-    !checkExistyKey((originalWDom.children || [])[0])
-  ) {
-    return false;
-  }
-
-  const origChildren = [...((originalWDom && originalWDom.children) || [])];
-  const newChildren = [...((newWDom && newWDom.children) || [])].filter(item =>
-    origChildren.find(newItem => getKey(item) === getKey(newItem))
-  );
-  const filteredChildren = origChildren.filter(item =>
-    newChildren.find(newItem => getKey(item) === getKey(newItem))
-  );
-  let isSame = filteredChildren.length === newChildren.length;
-
-  if (isSame) {
-    isSame = filteredChildren.every(
-      (item, index) => getKey(item) === getKey(newChildren[index])
-    );
-  }
-
-  return isSame;
+  return isSameType ? (isKeyChecked ? 'T' : 'U') : isKeyChecked ? 'S' : 'R';
 };
 
 /**
@@ -243,23 +196,34 @@ const remakeChildrenForDiff = (
 /**
  * Recursive handling for the creation of a new virtual DOM.
  */
-const remakeChildrenForAdd = (newWDom: WDom) =>
-  (newWDom.children || []).map((item: WDom) =>
-    assign(makeNewWDomTree(item), { getParent: () => newWDom })
-  );
+const remakeChildrenForAdd = (newWDom: WDom) => {
+  const getParent = () => newWDom;
+
+  return (newWDom.children || []).map((item: WDom) => {
+    const child = makeNewWDomTree(item);
+    child.getParent = getParent;
+    return child;
+  });
+};
 
 /**
  * Recursive handling for updates, not additions.
  * Uses key-based diffing for loops, index-based for others
  */
-const remakeChildrenForUpdate = (newWDom: WDom, originalWDom: WDom) =>
-  newWDom.type === 'l' && checkExistyKey((newWDom.children || [])[0]) // 'l': loop
-    ? remakeChildrenForLoopUpdate(newWDom, originalWDom)
-    : (newWDom.children || []).map((item: WDom, index: number) =>
-        assign(makeNewWDomTree(item, (originalWDom.children || [])[index]), {
-          getParent: () => newWDom,
-        })
-      );
+const remakeChildrenForUpdate = (newWDom: WDom, originalWDom: WDom) => {
+  if (newWDom.type === 'l' && checkExistyKey((newWDom.children || [])[0])) {
+    return remakeChildrenForLoopUpdate(newWDom, originalWDom);
+  }
+
+  const origChildren = originalWDom.children || [];
+  const getParent = () => newWDom;
+
+  return (newWDom.children || []).map((item: WDom, index: number) => {
+    const child = makeNewWDomTree(item, origChildren[index]);
+    child.getParent = getParent;
+    return child;
+  });
+};
 
 /**
  * Handling virtual DOM of loop-type elements.
@@ -270,37 +234,48 @@ const remakeChildrenForLoopUpdate = (newWDom: WDom, originalWDom: WDom) => {
     originalWDom
   );
 
-  unUsedChildren.forEach(unusedItem => {
-    runUnmountQueueFromWDom(unusedItem);
-    recursiveRemoveEvent(unusedItem);
-    typeDelete(unusedItem);
-  });
+  typeDeleteUnused(unUsedChildren);
 
   return remakedChildren;
 };
 
 /**
  * Recursive handling of loop-type virtual DOM elements.
+ * Matches children against the originals by key via a Map in O(n) and
+ * records each match's original index (oi) for the render phase to
+ * minimize moves via LIS.
  */
 const diffLoopChildren = (newWDom: WDom, originalWDom: WDom) => {
-  const origCh = [...(originalWDom.children || [])];
-  const remaked = (newWDom.children || []).map(item => {
-    const orig = findSameKeyOriginalItem(item, origCh);
-    const child = makeNewWDomTree(item, orig);
+  const origChildren = originalWDom.children || [];
+  const keyMap = new Map<unknown, number>();
+  origChildren.forEach((item, index) => {
+    const key = getKey(item);
+    if (!keyMap.has(key)) {
+      keyMap.set(key, index);
+    }
+  });
 
-    if (orig) origCh.splice(origCh.indexOf(orig), 1);
-    child.getParent = () => newWDom;
+  const getParent = () => newWDom;
+  const remaked = (newWDom.children || []).map(item => {
+    const key = getKey(item);
+    const origIndex = keyMap.get(key);
+    const matched = origIndex !== undefined;
+
+    if (matched) {
+      keyMap.delete(key);
+    }
+
+    const child = makeNewWDomTree(
+      item,
+      matched ? origChildren[origIndex] : undefined
+    );
+    if (matched) {
+      child.oi = origIndex;
+    }
+    child.getParent = getParent;
 
     return child;
   });
 
-  return [remaked, origCh];
+  return [remaked, [...keyMap.values()].map(index => origChildren[index])];
 };
-
-/**
- * When comparing loop-type virtual DOM elements, use the key to determine the comparison
- */
-const findSameKeyOriginalItem = (item: WDom, originalChildren: WDom[]) =>
-  originalChildren.find(
-    orignalChildItem => getKey(orignalChildItem) === getKey(item)
-  );

--- a/src/render.ts
+++ b/src/render.ts
@@ -83,9 +83,10 @@ export const typeDelete = (newWDom: WDom) => {
 
 const deleteRealDom = (newWDom: WDom, parent: HTMLElement) => {
   if (parent && newWDom.el) {
-    if (newWDom.el.nodeType === 11 || newWDom?.tag === 'portal') {
+    const nt = newWDom.el.nodeType;
+    if (nt === 11 || newWDom?.tag === 'portal') {
       findChildWithRemoveElement(newWDom, parent);
-    } else if ([1, 3].includes(newWDom.el.nodeType)) {
+    } else if (nt === 1 || nt === 3) {
       parent.removeChild(newWDom.el);
     }
 
@@ -153,18 +154,8 @@ const typeSortedReplace = (newWDom: WDom) => {
 const typeSortedUpdate = (newWDom: WDom) => {
   typeUpdate(newWDom);
 
-  const parentWDom = getParent(newWDom);
-  if (!parentWDom) {
-    if (newWDom.isRoot) {
-      const newElement = getElementFromFragment(newWDom);
-      typeAdd(newWDom, newElement);
-    }
-    return;
-  }
-  if (parentWDom.nr !== 'L') {
-    const newElement = getElementFromFragment(newWDom);
-
-    typeAdd(newWDom, newElement);
+  if (getParent(newWDom) || newWDom.isRoot) {
+    typeAdd(newWDom, getElementFromFragment(newWDom));
   }
 };
 
@@ -197,17 +188,14 @@ const typeAdd = (
   }
 
   const parentEl = findRealParentElement(parentWDom);
-  const isLoop = parentWDom.type === 'l';
   const nextEl =
-    isLoop && parentWDom.nr && parentWDom.nr !== 'L'
+    parentWDom.type === 'l' && parentWDom.nr
       ? startFindNextBrotherElement(parentWDom, getParent(parentWDom))
       : startFindNextBrotherElement(newWDom, parentWDom);
 
   if (newElement && parentEl) {
     if (newWDom.tag !== 'portal') {
-      nextEl
-        ? parentEl.insertBefore(newElement, nextEl)
-        : parentEl.appendChild(newElement);
+      parentEl.insertBefore(newElement, nextEl || null);
     }
     execMountedQueue();
   }
@@ -347,12 +335,7 @@ const updateChildren = (newWDom: WDom) => {
 
   if (newWDom.type === 'l') {
     for (const item of children) {
-      if (
-        item.nr === 'A' ||
-        item.nr === 'T' ||
-        item.nr === 'S' ||
-        item.oi !== undefined
-      ) {
+      if ('ATS'.includes(item.nr as string) || item.oi !== undefined) {
         needPlace = true;
         break;
       }
@@ -369,14 +352,18 @@ const updateChildren = (newWDom: WDom) => {
   const created: (HTMLElement | DocumentFragment | Text | undefined)[] = [];
   const matchedIndexes: number[] = [];
   const oiSeq: number[] = [];
+  let createdCount = 0;
 
   children.forEach((item, index) => {
-    if (item.nr === 'A' || item.nr === 'S') {
-      if (item.nr === 'S') {
+    const nr = item.nr;
+
+    if (nr === 'A' || nr === 'S') {
+      if (nr === 'S') {
         typeDelete(item);
       }
       created[index] = wDomToDom(item);
-    } else if (item.nr === 'T') {
+      createdCount++;
+    } else if (nr === 'T') {
       typeUpdate(item);
     } else {
       wDomUpdate(item);
@@ -388,53 +375,35 @@ const updateChildren = (newWDom: WDom) => {
     }
   });
 
-  const stay = new Set<number>();
-  getLisPositions(oiSeq).forEach(pos => stay.add(matchedIndexes[pos]));
-
+  const stay = new Set(getLisPositions(oiSeq).map(pos => matchedIndexes[pos]));
   const parentEl = findRealParentElement(newWDom);
   const baseAnchor = newWDom.isRoot
     ? newWDom.ae
     : startFindNextBrotherElement(newWDom, getParent(newWDom));
 
   // Fast-append the trailing run of added children in order
-  // (appendChild instead of insertBefore-walking from the right).
+  // (a null anchor makes insertBefore behave as appendChild).
   let tail = children.length;
   while (tail > 0 && created[tail - 1] !== undefined) {
     tail--;
   }
 
   for (let i = tail; i < children.length; i++) {
-    const item = children[i];
     const el = created[i];
 
-    if (el && parentEl && item.tag !== 'portal') {
-      baseAnchor
-        ? parentEl.insertBefore(el, baseAnchor)
-        : parentEl.appendChild(el);
-    }
-    clearDiffMeta(item);
-  }
-
-  const hasMove = stay.size !== matchedIndexes.length;
-  let hasLeftNew = false;
-  for (let i = 0; i < tail; i++) {
-    if (created[i] !== undefined) {
-      hasLeftNew = true;
-      break;
+    if (el && parentEl && children[i].tag !== 'portal') {
+      parentEl.insertBefore(el, baseAnchor || null);
     }
   }
 
-  if (hasMove || hasLeftNew) {
+  if (
+    stay.size !== matchedIndexes.length ||
+    createdCount > children.length - tail
+  ) {
     // Placement pass (right-to-left): insert added children and non-LIS
     // moves before a running anchor.
-    let anchor = baseAnchor;
-    for (let k = tail; k < children.length; k++) {
-      const el = findChildFragmentNextElement([children[k]]);
-      if (el) {
-        anchor = el;
-        break;
-      }
-    }
+    let anchor =
+      findChildFragmentNextElement(children.slice(tail)) || baseAnchor;
 
     for (let i = tail - 1; i >= 0; i--) {
       const item = children[i];
@@ -442,14 +411,10 @@ const updateChildren = (newWDom: WDom) => {
       const needMove = item.oi !== undefined && !isNew && !stay.has(i);
 
       if ((isNew || needMove) && parentEl && item.tag !== 'portal') {
-        const el = isNew
-          ? created[i]
-          : checkVirtualType(item.type)
-            ? getElementFromFragment(item)
-            : item.el;
+        const el = isNew ? created[i] : getElementFromFragment(item);
 
         if (el) {
-          anchor ? parentEl.insertBefore(el, anchor) : parentEl.appendChild(el);
+          parentEl.insertBefore(el, anchor || null);
         }
       }
 
@@ -457,15 +422,10 @@ const updateChildren = (newWDom: WDom) => {
       if (first) {
         anchor = first;
       }
-
-      clearDiffMeta(item);
-    }
-  } else {
-    for (let i = 0; i < tail; i++) {
-      clearDiffMeta(children[i]);
     }
   }
 
+  children.forEach(clearDiffMeta);
   execMountedQueue();
 };
 
@@ -533,10 +493,7 @@ export const wDomUpdate = (newWDomTree: WDom) => {
 
   if (needRerender !== undefined && needRerender !== 'N') {
     renderHandlers[needRerender](newWDomTree);
-
-    delete newWDomTree.nr;
-    delete newWDomTree.oc;
-    delete newWDomTree.op;
+    clearDiffMeta(newWDomTree);
   }
 };
 
@@ -547,7 +504,6 @@ const renderHandlers = {
   U: typeUpdate,
   S: typeSortedReplace,
   T: typeSortedUpdate,
-  L: typeUpdate,
 } as const;
 
 const updateText = (newWDom: WDom) => {
@@ -582,7 +538,7 @@ const updateProps = (
         originalProps[dataKey] as (e: Event) => void
       );
     } else {
-      if (dataKey === 'key' || dataValue === originalProps[dataKey]) {
+      if (dataKey === 'key') {
         // Do nothing
       } else if (dataKey === 'portal' && isObject(dataValue)) {
         // Do nothing

--- a/src/render.ts
+++ b/src/render.ts
@@ -12,7 +12,7 @@ import { runUnmountQueueFromWDom } from '@/hook/internal/unmount';
 import { execMountedQueue, addMountedQueue } from '@/hook/mountCallback';
 import { runWDomCallbacksFromWDom } from '@/hook/mountReadyCallback';
 import { runUpdatedQueueFromWDom } from '@/hook/internal/useUpdate';
-import { getParent, entries, keys, isObject } from '@/utils';
+import { getParent, isObject } from '@/utils';
 
 const DF = () => new DocumentFragment();
 const CE = (t: string) => document.createElement(t);
@@ -94,19 +94,55 @@ const deleteRealDom = (newWDom: WDom, parent: HTMLElement) => {
 };
 
 const findChildWithRemoveElement = (newWDom: WDom, parent: HTMLElement) => {
-  ((newWDom && newWDom.oc) || (newWDom && newWDom.children) || []).forEach(
-    item => {
+  const items = (newWDom && newWDom.oc) || (newWDom && newWDom.children) || [];
+
+  // Bulk fast path: the parent element contains exactly these children,
+  // so they can all be dropped in a single operation.
+  // (counted via sibling pointers -- childNodes would materialize a live list)
+  let count = 0;
+  for (let node = parent.firstChild; node; node = node.nextSibling) {
+    count++;
+  }
+
+  if (
+    items.length > 1 &&
+    count === items.length &&
+    items.every(item => {
       const nt = item.el && item.el.nodeType;
-      if (nt) {
-        if ([1, 3].includes(nt)) {
-          const el = item.el as HTMLElement;
-          el.tagName === 'HTML' ? (el.innerHTML = '') : el.remove();
-        } else if (nt === 11) {
-          findChildWithRemoveElement(item, parent);
-        }
+      return (
+        (nt === 1 || nt === 3) &&
+        (item.el as HTMLElement).tagName !== 'HTML' &&
+        item.tag !== 'portal'
+      );
+    })
+  ) {
+    parent.textContent = '';
+    items.forEach(item => delete item.el);
+    return;
+  }
+
+  items.forEach(item => {
+    const nt = item.el && item.el.nodeType;
+    if (nt) {
+      if (nt === 1 || nt === 3) {
+        const el = item.el as HTMLElement;
+        el.tagName === 'HTML' ? (el.innerHTML = '') : el.remove();
+      } else if (nt === 11) {
+        findChildWithRemoveElement(item, parent);
       }
     }
-  );
+  });
+};
+
+/**
+ * Unmount, detach events, and remove unused keyed children.
+ */
+export const typeDeleteUnused = (items: WDom[]) => {
+  items.forEach(item => {
+    runUnmountQueueFromWDom(item);
+    recursiveRemoveEvent(item);
+    typeDelete(item);
+  });
 };
 
 const typeSortedReplace = (newWDom: WDom) => {
@@ -266,14 +302,14 @@ const removeEvent = (
   oldProps: Props,
   element: HTMLElement | DocumentFragment | Text
 ) => {
-  entries(oldProps || {}).forEach(([dataKey, dataValue]: [string, unknown]) => {
-    if (dataKey.match(/^on/)) {
+  for (const dataKey in oldProps) {
+    if (dataKey[0] === 'o' && dataKey[1] === 'n') {
       element.removeEventListener(
         dataKey.slice(2).toLowerCase(),
-        dataValue as (e: Event) => void
+        oldProps[dataKey] as (e: Event) => void
       );
     }
-  });
+  }
 };
 
 const typeUpdate = (newWDom: WDom) => {
@@ -294,8 +330,202 @@ const typeUpdate = (newWDom: WDom) => {
     }
   }
 
-  (newWDom.children || []).forEach(childItem => wDomUpdate(childItem));
+  updateChildren(newWDom);
   runUpdatedQueueFromWDom(newWDom);
+};
+
+/**
+ * Process child updates. Loop parents with added/moved children are handled
+ * in O(n): a left-to-right content pass (keeps lifecycle order), an LIS over
+ * the matched original indices (oi, recorded by the diff phase) to pick the
+ * children that can stay in place, and a right-to-left placement pass that
+ * inserts only added children and non-LIS moves before a running anchor.
+ */
+const updateChildren = (newWDom: WDom) => {
+  const children = newWDom.children || [];
+  let needPlace = false;
+
+  if (newWDom.type === 'l') {
+    for (const item of children) {
+      if (
+        item.nr === 'A' ||
+        item.nr === 'T' ||
+        item.nr === 'S' ||
+        item.oi !== undefined
+      ) {
+        needPlace = true;
+        break;
+      }
+    }
+  }
+
+  if (!needPlace) {
+    children.forEach(childItem => wDomUpdate(childItem));
+    return;
+  }
+
+  // Content pass (left-to-right, keeps lifecycle order).
+  // Added children are created here but inserted in the placement pass.
+  const created: (HTMLElement | DocumentFragment | Text | undefined)[] = [];
+  const matchedIndexes: number[] = [];
+  const oiSeq: number[] = [];
+
+  children.forEach((item, index) => {
+    if (item.nr === 'A' || item.nr === 'S') {
+      if (item.nr === 'S') {
+        typeDelete(item);
+      }
+      created[index] = wDomToDom(item);
+    } else if (item.nr === 'T') {
+      typeUpdate(item);
+    } else {
+      wDomUpdate(item);
+    }
+
+    if (item.oi !== undefined && created[index] === undefined) {
+      matchedIndexes.push(index);
+      oiSeq.push(item.oi);
+    }
+  });
+
+  const stay = new Set<number>();
+  getLisPositions(oiSeq).forEach(pos => stay.add(matchedIndexes[pos]));
+
+  const parentEl = findRealParentElement(newWDom);
+  const baseAnchor = newWDom.isRoot
+    ? newWDom.ae
+    : startFindNextBrotherElement(newWDom, getParent(newWDom));
+
+  // Fast-append the trailing run of added children in order
+  // (appendChild instead of insertBefore-walking from the right).
+  let tail = children.length;
+  while (tail > 0 && created[tail - 1] !== undefined) {
+    tail--;
+  }
+
+  for (let i = tail; i < children.length; i++) {
+    const item = children[i];
+    const el = created[i];
+
+    if (el && parentEl && item.tag !== 'portal') {
+      baseAnchor
+        ? parentEl.insertBefore(el, baseAnchor)
+        : parentEl.appendChild(el);
+    }
+    clearDiffMeta(item);
+  }
+
+  const hasMove = stay.size !== matchedIndexes.length;
+  let hasLeftNew = false;
+  for (let i = 0; i < tail; i++) {
+    if (created[i] !== undefined) {
+      hasLeftNew = true;
+      break;
+    }
+  }
+
+  if (hasMove || hasLeftNew) {
+    // Placement pass (right-to-left): insert added children and non-LIS
+    // moves before a running anchor.
+    let anchor = baseAnchor;
+    for (let k = tail; k < children.length; k++) {
+      const el = findChildFragmentNextElement([children[k]]);
+      if (el) {
+        anchor = el;
+        break;
+      }
+    }
+
+    for (let i = tail - 1; i >= 0; i--) {
+      const item = children[i];
+      const isNew = created[i] !== undefined;
+      const needMove = item.oi !== undefined && !isNew && !stay.has(i);
+
+      if ((isNew || needMove) && parentEl && item.tag !== 'portal') {
+        const el = isNew
+          ? created[i]
+          : checkVirtualType(item.type)
+            ? getElementFromFragment(item)
+            : item.el;
+
+        if (el) {
+          anchor ? parentEl.insertBefore(el, anchor) : parentEl.appendChild(el);
+        }
+      }
+
+      const first = findChildFragmentNextElement([item]);
+      if (first) {
+        anchor = first;
+      }
+
+      clearDiffMeta(item);
+    }
+  } else {
+    for (let i = 0; i < tail; i++) {
+      clearDiffMeta(children[i]);
+    }
+  }
+
+  execMountedQueue();
+};
+
+const clearDiffMeta = (item: WDom) => {
+  delete item.oi;
+  delete item.nr;
+  delete item.oc;
+  delete item.op;
+};
+
+/**
+ * Longest increasing subsequence positions (binary search, O(n log n)).
+ * Returns the positions in seq that form the LIS.
+ */
+const getLisPositions = (seq: number[]) => {
+  const result: number[] = [];
+
+  if (!seq.length) {
+    return result;
+  }
+
+  const prev = new Array(seq.length);
+  result.push(0);
+
+  for (let i = 1; i < seq.length; i++) {
+    const value = seq[i];
+
+    if (seq[result[result.length - 1]] < value) {
+      prev[i] = result[result.length - 1];
+      result.push(i);
+      continue;
+    }
+
+    let lo = 0;
+    let hi = result.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (seq[result[mid]] < value) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+
+    if (value < seq[result[lo]]) {
+      if (lo > 0) {
+        prev[i] = result[lo - 1];
+      }
+      result[lo] = i;
+    }
+  }
+
+  let i = result.length;
+  let last = result[i - 1];
+  while (i-- > 0) {
+    result[i] = last;
+    last = prev[last];
+  }
+
+  return result;
 };
 
 export const wDomUpdate = (newWDomTree: WDom) => {
@@ -334,13 +564,17 @@ const updateProps = (
 ) => {
   const originalProps = oldProps || {};
 
-  entries(props || {}).forEach(([dataKey, dataValue]: [string, unknown]) => {
+  for (const dataKey in props) {
+    const dataValue: unknown = props[dataKey];
+
     if (dataValue === originalProps[dataKey]) {
       delete originalProps[dataKey];
-      return;
+      continue;
     }
 
-    if (isHydration && dataKey.match(/^on/)) {
+    const isEvent = dataKey[0] === 'o' && dataKey[1] === 'n';
+
+    if (isHydration && isEvent) {
       updateEvent(
         element as HTMLElement,
         dataKey,
@@ -364,7 +598,7 @@ const updateProps = (
         );
       } else if (checkRefData(dataKey, dataValue)) {
         dataValue.value = element;
-      } else if (dataKey.match(/^on/)) {
+      } else if (isEvent) {
         updateEvent(
           element as HTMLElement,
           dataKey,
@@ -386,11 +620,11 @@ const updateProps = (
 
       delete originalProps[dataKey];
     }
-  });
+  }
 
-  keys(originalProps).forEach(dataKey =>
-    (element as HTMLElement).removeAttribute(dataKey)
-  );
+  for (const dataKey in originalProps) {
+    (element as HTMLElement).removeAttribute(dataKey);
+  }
 };
 
 const setAttr = (k: string, el: HTMLElement, v: string) =>
@@ -453,19 +687,16 @@ const wDomChildrenToDom = (
   parentElement?: HTMLElement | Element | DocumentFragment | Text,
   isHydration?: boolean
 ) => {
-  const frag = children.reduce((acc: DocumentFragment, childItem: WDom) => {
+  // The parent is not attached to the document yet, so children can be
+  // appended directly (no intermediate fragment allocation).
+  children.forEach((childItem: WDom) => {
     if (childItem.type) {
       const childElement = wDomToDom(childItem, isHydration);
-      if (childItem.tag !== 'portal' && !isHydration) {
-        acc.appendChild(childElement);
+      if (childItem.tag !== 'portal' && !isHydration && parentElement) {
+        parentElement.appendChild(childElement);
       }
     }
-    return acc;
-  }, DF());
-
-  if (!isHydration && parentElement && frag.hasChildNodes()) {
-    parentElement.appendChild(frag);
-  }
+  });
 };
 
 const updateEvent = (
@@ -500,14 +731,14 @@ const updateStyle = (
 
   const styleProxy = cssStyle as unknown as Record<string, string>;
 
-  entries(style).forEach(([k, v]) => {
-    styleProxy[k] = v;
+  for (const k in style) {
+    styleProxy[k] = style[k];
     delete orig[k];
-  });
+  }
 
-  entries(orig).forEach(([k]) => {
+  for (const k in orig) {
     styleProxy[k] = '';
-  });
+  }
 };
 
 const findRealParentElement = (

--- a/src/tests/core-loopLifecycleOrder.tsx
+++ b/src/tests/core-loopLifecycleOrder.tsx
@@ -1,0 +1,68 @@
+import { h, render, mount, ref, nextTick, mountCallback } from '@/index';
+
+const changeRef = ref<null | ((ids: number[]) => void)>(null);
+const mountLog: number[] = [];
+const unmountLog: number[] = [];
+
+const Row = mount<{ id: number }>((_renew, props) => {
+  mountCallback(() => {
+    mountLog.push(props.id);
+    return () => {
+      unmountLog.push(props.id);
+    };
+  });
+
+  return ({ id }) => <li>{id}</li>;
+});
+
+const Loop = mount(function (renew) {
+  let list: number[] = [1, 2, 3];
+
+  changeRef.value = (ids: number[]) => {
+    list = ids;
+    renew();
+  };
+
+  return () => (
+    <ul>
+      {list.map(id => (
+        <Row key={id} id={id} />
+      ))}
+    </ul>
+  );
+});
+
+const testWrap =
+  document.getElementById('root') || document.createElement('div');
+
+render(<Loop />, testWrap);
+
+if (import.meta.vitest) {
+  const { it, expect } = import.meta.vitest;
+
+  const change = async (ids: number[]) => {
+    changeRef.value!(ids);
+    await nextTick();
+  };
+
+  it('runs mount callbacks for the initial rows left-to-right', () => {
+    expect(mountLog).toEqual([1, 2, 3]);
+  });
+
+  it('runs mount callbacks for keyed insertions left-to-right', async () => {
+    await change([1, 9, 2, 10, 3, 11]);
+    expect(mountLog).toEqual([1, 2, 3, 9, 10, 11]);
+    expect(unmountLog).toEqual([]);
+  });
+
+  it('does not remount rows that only moved', async () => {
+    await change([11, 9, 2, 10, 3, 1]);
+    expect(mountLog).toEqual([1, 2, 3, 9, 10, 11]);
+    expect(unmountLog).toEqual([]);
+  });
+
+  it('runs unmount callbacks for removed rows in original order', async () => {
+    await change([2, 3]);
+    expect(unmountLog).toEqual([11, 9, 10, 1]);
+  });
+}

--- a/src/tests/core-loopLifecycleOrder.tsx
+++ b/src/tests/core-loopLifecycleOrder.tsx
@@ -4,7 +4,7 @@ const changeRef = ref<null | ((ids: number[]) => void)>(null);
 const mountLog: number[] = [];
 const unmountLog: number[] = [];
 
-const Row = mount<{ id: number }>((_renew, props) => {
+const Row = mount<{ key: number; id: number }>((_renew, props) => {
   mountCallback(() => {
     mountLog.push(props.id);
     return () => {

--- a/src/tests/core-loopMoveOrder.tsx
+++ b/src/tests/core-loopMoveOrder.tsx
@@ -1,0 +1,77 @@
+import { h, render, mount, ref, nextTick } from '@/index';
+
+const changeRef = ref<null | ((ids: number[]) => void)>(null);
+
+const Loop = mount(function (renew) {
+  let list: number[] = [1, 2, 3, 4, 5];
+
+  changeRef.value = (ids: number[]) => {
+    list = ids;
+    renew();
+  };
+
+  return () => (
+    <ul>
+      {list.map(id => (
+        <li key={id}>{id}</li>
+      ))}
+      <li class="tail">tail</li>
+    </ul>
+  );
+});
+
+const testWrap =
+  document.getElementById('root') || document.createElement('div');
+
+render(<Loop />, testWrap);
+
+const listHtml = (ids: number[]) =>
+  `<ul>${ids.map(id => `<li>${id}</li>`).join('')}<li class="tail">tail</li></ul>`;
+
+if (import.meta.vitest) {
+  const { it, expect } = import.meta.vitest;
+
+  const change = async (ids: number[]) => {
+    changeRef.value!(ids);
+    await nextTick();
+  };
+
+  it('renders the initial keyed list in order', () => {
+    expect(testWrap.innerHTML).toBe(listHtml([1, 2, 3, 4, 5]));
+  });
+
+  it('swaps two distant rows with the rest untouched', async () => {
+    await change([1, 4, 3, 2, 5]);
+    expect(testWrap.innerHTML).toBe(listHtml([1, 4, 3, 2, 5]));
+  });
+
+  it('reverses the whole list', async () => {
+    await change([5, 2, 3, 4, 1]);
+    expect(testWrap.innerHTML).toBe(listHtml([5, 2, 3, 4, 1]));
+  });
+
+  it('handles shuffle with removals and insertions mixed', async () => {
+    await change([3, 1, 6, 4, 7]);
+    expect(testWrap.innerHTML).toBe(listHtml([3, 1, 6, 4, 7]));
+  });
+
+  it('appends at the end without crossing the list boundary sibling', async () => {
+    await change([3, 1, 6, 4, 7, 8, 9]);
+    expect(testWrap.innerHTML).toBe(listHtml([3, 1, 6, 4, 7, 8, 9]));
+  });
+
+  it('prepends and inserts in the middle', async () => {
+    await change([0, 3, 1, 6, 5, 4, 7, 8, 9]);
+    expect(testWrap.innerHTML).toBe(listHtml([0, 3, 1, 6, 5, 4, 7, 8, 9]));
+  });
+
+  it('clears every row while keeping the boundary sibling', async () => {
+    await change([]);
+    expect(testWrap.innerHTML).toBe(listHtml([]));
+  });
+
+  it('refills after a full clear', async () => {
+    await change([1, 2]);
+    expect(testWrap.innerHTML).toBe(listHtml([1, 2]));
+  });
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,7 +88,6 @@ export type RenderType =
   | 'U' // UPDATE
   | 'S' // SORTED_REPLACE (was SR)
   | 'T' // SORTED_UPDATE (was SU)
-  | 'L' // LOOP_CHILDREN_NOT_SORTED_UPDATE (was CNSU)
   | 'N'; // NONE
 
 export type ComponentSubKey =

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,6 +76,7 @@ export interface WDom {
   ae?: HTMLElement; // afterElement (insert before)
   el?: HTMLElement | DocumentFragment | Text;
   nr?: RenderType; // needRerender
+  oi?: number; // originalIndex (matched keyed position in previous children)
   il?: boolean; // isLegacy
   [wdomSymbol]?: boolean | 'provider';
 }

--- a/src/utils/predicator.ts
+++ b/src/utils/predicator.ts
@@ -93,8 +93,9 @@ export const getKey = (target: WDom) =>
  * Check if the type is virtual (fragment or loop)
  * Virtual types don't create real DOM elements themselves
  */
-export const checkVirtualType = (type?: string | null) =>
-  type && ['f', 'l'].includes(type); // 'f': fragment, 'l': loop
+export const checkVirtualType = (
+  type?: string | null // 'f': fragment, 'l': loop
+) => type === 'f' || type === 'l';
 
 export const checkCustemComponentFunction = (
   target: WDomParam
@@ -128,13 +129,24 @@ export const checkRefData = (
   value: HTMLElement | Element | DocumentFragment | Text | undefined;
 } => dataKey === 'ref' && isObject(dataValue);
 
-export const hasAccessorMethods = (target: unknown, dataKey: string) => {
-  const descriptor = Object.getOwnPropertyDescriptor(
-    target!.constructor.prototype,
-    dataKey
-  );
+// Descriptor lookups are cached per nodeName+key (HTML nodeName is uppercase,
+// SVG lowercase, so the two prototypes never collide on the same cache key).
+const accessorCache = new Map<string, boolean>();
 
-  return descriptor && descriptor.get && descriptor.set;
+export const hasAccessorMethods = (target: unknown, dataKey: string) => {
+  const cacheKey = (target as HTMLElement).nodeName + '|' + dataKey;
+  let result = accessorCache.get(cacheKey);
+
+  if (result === undefined) {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      target!.constructor.prototype,
+      dataKey
+    );
+    result = !!(descriptor && descriptor.get && descriptor.set);
+    accessorCache.set(cacheKey, result);
+  }
+
+  return result;
 };
 
 /**

--- a/src/wDom.ts
+++ b/src/wDom.ts
@@ -204,10 +204,16 @@ const makeNode = (
 const remakeChildren = (
   nodeParentPointer: NodePointer,
   children: MiddleStateWDomChildren
-): WDom[] =>
-  children.map((item: MiddleStateWDom) =>
-    assign(makeChildrenItem(item), { getParent: () => nodeParentPointer.value })
-  );
+): WDom[] => {
+  // Siblings share a single getParent closure (one allocation per parent)
+  const getParent = () => nodeParentPointer.value;
+
+  return children.map((item: MiddleStateWDom) => {
+    const childItem = makeChildrenItem(item);
+    childItem.getParent = getParent;
+    return childItem;
+  });
+};
 
 /**
  * Recursively process the child virtual DOM elements.


### PR DESCRIPTION
- Replace O(n^2) keyed child matching (find/splice) with Map lookup, recording each match's original index (oi) for the render phase
- Minimize DOM moves on reorder via LIS: only non-LIS children are re-inserted, with a single right-to-left placement pass and an appendChild fast path for trailing insertions
- Remove chkDiffLoopOrder and the 'L' render type assignment
- Share one getParent closure per parent instead of one per child
- Replace regex/entries prop scans with for-in and char checks, cache accessor descriptor lookups per nodeName+key
- Drop intermediate DocumentFragment per parent in initial DOM build
- Bulk-remove children on full list clear when the parent contains nothing else
- Add keyed reorder / lifecycle order regression tests and performance docs (REQUIREMENTS/DESIGN/IMPLEMENT/MANUAL_TEST_CHECKLIST) with reproducible benchmark scripts

10k-row scenarios (jsdom): swap 2719ms -> ~90ms, append 3031ms -> ~100ms, partial update 700ms -> ~100ms, create 414ms -> ~300ms. Bundle: 4169B -> 4797B brotli (budget 5120B).